### PR TITLE
fix: pass abort signal into effect

### DIFF
--- a/__tests__/atomEffect.test.ts
+++ b/__tests__/atomEffect.test.ts
@@ -1,5 +1,6 @@
-import { useEffect } from 'react'
-import { act, renderHook, waitFor } from '@testing-library/react'
+import { createElement, useEffect } from 'react'
+import { act, render, renderHook, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai/react'
 import { atom } from 'jotai/vanilla'
 import { atomEffect } from '../src/atomEffect'
@@ -593,6 +594,64 @@ it('should run the effect once even if the effect is mounted multiple times', as
     setNumbers(increment)
   })
   expect(runCount).toBe(3)
+})
+
+it('should run abort the effect when the effect is unmounted even the effect is pending', async () => {
+  let abortedCount = 0
+  const countAtom = atom(0)
+  const resolve: (() => void)[] = []
+  const effectAtom = atomEffect(async (get, __, { signal }) => {
+    get(countAtom)
+    const callback = () => {
+      ++abortedCount
+    }
+    signal.addEventListener('abort', callback)
+    await new Promise<void>((r) => resolve.push(r))
+    signal.removeEventListener('abort', callback)
+  })
+
+  const Component = () => {
+    useAtomValue(effectAtom)
+    const count = useAtomValue(countAtom)
+    return `count: ${count}`
+  }
+
+  const Controls = () => {
+    const setCount = useSetAtom(countAtom)
+    return createElement(
+      'button',
+      {
+        onClick: () => {
+          setCount(increment)
+        },
+      },
+      'button'
+    )
+  }
+
+  const { findByText } = render(
+    createElement('div', {}, [
+      createElement(Component, { key: 'component' }),
+      createElement(Controls, { key: 'controls' }),
+    ])
+  )
+
+  await findByText('count: 0')
+  expect(resolve.length).toBe(1)
+  await userEvent.click(await findByText('button'))
+  await findByText('count: 1')
+  expect(resolve.length).toBe(1)
+  resolve.forEach((r) => r())
+
+  await userEvent.click(await findByText('button'))
+  await findByText('count: 2')
+  expect(resolve.length).toBe(2)
+
+  expect(abortedCount).toBe(0)
+  await userEvent.click(await findByText('button'))
+  await userEvent.click(await findByText('button'))
+  resolve.forEach((r) => r())
+  expect(abortedCount).toBe(1)
 })
 
 function increment(count: number) {

--- a/__tests__/atomEffect.test.ts
+++ b/__tests__/atomEffect.test.ts
@@ -596,7 +596,7 @@ it('should run the effect once even if the effect is mounted multiple times', as
   expect(runCount).toBe(3)
 })
 
-it('should run abort the effect when the effect is unmounted even the effect is pending', async () => {
+it('should run the abort signal cleanup when the effect is ignored', async () => {
   let abortedCount = 0
   const countAtom = atom(0)
   const resolve: (() => void)[] = []

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "license": "MIT",
   "devDependencies": {
     "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.5.1",
     "@types/jest": "^29.5.5",
     "@types/node": "^20.8.3",
     "@types/react": "^18.2.25",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,16 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 devDependencies:
   '@testing-library/react':
     specifier: ^14.0.0
     version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
+  '@testing-library/user-event':
+    specifier: ^14.5.1
+    version: 14.5.1(@testing-library/dom@9.3.3)
   '@types/jest':
     specifier: ^29.5.5
     version: 29.5.5
@@ -1905,6 +1912,15 @@ packages:
       '@types/react-dom': 18.2.11
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: true
+
+  /@testing-library/user-event@14.5.1(@testing-library/dom@9.3.3):
+    resolution: {integrity: sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+    dependencies:
+      '@testing-library/dom': 9.3.3
     dev: true
 
   /@tootallnate/once@2.0.0:


### PR DESCRIPTION
> @himself65 Although, it's quite clear, can you write the PR description? Like background/motivation/intention. Did you hit a real issue? Is it an hypothetical improvement?

Yep. Imaging the effectAtom will connect the server and continuously fetch the data based on your `idAtom`. And there's a button that increases the ID. And if click the button multiple times. There could be race conditions based on the network situation. I think the situation is easy to simulate, for example, the first fetch is a response later than the later one, it's a race condition in this case.

```ts
effectAtom(async (get, _, { signal }) => {
  const server = new Server(get(idAtom))
  server.connect()
  //If this hangs up and never resolved, we need an abort signal here
  //also could have race conditions when id changes
  const data = await server.initData(signal)
  set(dataAtom, data)

  server.on('update', (update) => set(dataAtom, d => [...d, update]))

  return () => {
    server.disconnect()
  }
})
``` 

there could be another approach, but I think it will make data flow harder to control

```ts
effectAtom(get => {
  const server = new Server(get(idAtom))
  server.connect()
  const ac = new AbortController()
  server.initData(ac.signal).then(data => {
    set(dataAtom, data)
    server.on('update', (update) => set(dataAtom, d => [...d, update]))
  })

  return () => {
    ac.abort()
    server.disconnect()
  }
})
```
