### PR TITLE
Revert "fix: pass abort signal into effect"

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "license": "MIT",
   "devDependencies": {
     "@testing-library/react": "^14.0.0",
-    "@testing-library/user-event": "^14.5.1",
     "@types/jest": "^29.5.5",
     "@types/node": "^20.8.3",
     "@types/react": "^18.2.25",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,16 +1,9 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 devDependencies:
   '@testing-library/react':
     specifier: ^14.0.0
     version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
-  '@testing-library/user-event':
-    specifier: ^14.5.1
-    version: 14.5.1(@testing-library/dom@9.3.3)
   '@types/jest':
     specifier: ^29.5.5
     version: 29.5.5
@@ -1912,15 +1905,6 @@ packages:
       '@types/react-dom': 18.2.11
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: true
-
-  /@testing-library/user-event@14.5.1(@testing-library/dom@9.3.3):
-    resolution: {integrity: sha512-UCcUKrUYGj7ClomOo2SpNVvx4/fkd/2BbIHDCle8A0ax+P3bU7yJwDBDrS6ZwdTMARWTGODX1hEsCcO+7beJjg==}
-    engines: {node: '>=12', npm: '>=6'}
-    peerDependencies:
-      '@testing-library/dom': '>=7.21.4'
-    dependencies:
-      '@testing-library/dom': 9.3.3
     dev: true
 
   /@tootallnate/once@2.0.0:

--- a/src/atomEffect.ts
+++ b/src/atomEffect.ts
@@ -5,13 +5,7 @@ type PromiseOrValue<T> = Promise<T> | T
 type CleanupFn = () => PromiseOrValue<void>
 
 export function atomEffect(
-  effectFn: (
-    get: Getter,
-    set: Setter,
-    options: {
-      signal: AbortSignal
-    }
-  ) => PromiseOrValue<void | CleanupFn>
+  effectFn: (get: Getter, set: Setter) => PromiseOrValue<void | CleanupFn>
 ) {
   const refAtom = atom(() => ({
     mounted: false,
@@ -47,7 +41,7 @@ export function atomEffect(
   }
 
   const effectAtom = atom(
-    async (get, { setSelf, signal }) => {
+    async (get, { setSelf }) => {
       get(refreshAtom)
       const ref = get(refAtom)
       if (!ref.mounted || ref.inProgress) {
@@ -56,7 +50,7 @@ export function atomEffect(
       ++ref.inProgress
       try {
         await ref.cleanup?.()
-        ref.cleanup = await effectFn(get, setSelf as Setter, { signal })
+        ref.cleanup = await effectFn(get, setSelf as Setter)
       } finally {
         --ref.inProgress
       }


### PR DESCRIPTION
Reverts jotaijs/jotai-effect#7

I need to remove `signal` from atomEffect.

Because run 2 early returns due to inProgress > 0, we cannot use an abort signal.

1. the atomEffect is triggered. An async effect is running (run 1)
2. some time later, the atomEffect is triggered again (run 2)
3. this time (run 2) early returns because (run 1) is still in progress
4. abort signal is fired because of (run 2), (run 1) aborts the fetch or whatever

Unfortunately, I need to revert this PR. We should spend more time thinking about this use case and find a workaround.