### PR TITLE
fix: remove async support from effectFn and cleanupFn

### DIFF
--- a/src/atomEffect.ts
+++ b/src/atomEffect.ts
@@ -1,11 +1,10 @@
 import type { Getter, Setter } from 'jotai/vanilla'
 import { atom } from 'jotai/vanilla'
 
-type PromiseOrValue<T> = Promise<T> | T
-type CleanupFn = () => PromiseOrValue<void>
+type CleanupFn = () => void
 
 export function atomEffect(
-  effectFn: (get: Getter, set: Setter) => PromiseOrValue<void | CleanupFn>
+  effectFn: (get: Getter, set: Setter) => void | CleanupFn
 ) {
   const refAtom = atom(() => ({
     mounted: false,
@@ -49,8 +48,9 @@ export function atomEffect(
       }
       ++ref.inProgress
       try {
-        await ref.cleanup?.()
-        ref.cleanup = await effectFn(get, setSelf as Setter)
+        await void 0
+        ref.cleanup?.()
+        ref.cleanup = effectFn(get, setSelf as Setter)
       } finally {
         --ref.inProgress
       }


### PR DESCRIPTION
Remove async support from effectFn and cleanupFn.

Related Discussion: https://github.com/jotaijs/jotai-effect/discussions/10
Related PR: https://github.com/pmndrs/jotai/pull/2189

TODO: bump minor after this change.