### PR TITLE
fix: jotai v2.5.0 atomEffect should rerun on deps change in StrictMode

### DIFF
--- a/__tests__/atomEffect.test.ts
+++ b/__tests__/atomEffect.test.ts
@@ -634,7 +634,7 @@ describe.only('should not run the effect when the effectAtom is unmounted', () =
     })
     function useTest() {
       useAtom(effectAtom)
-      return useSetAtom(countAtom)
+      return useAtom(countAtom)[1]
     }
     const { result } = renderHook(useTest)
     const setCount = result.current

--- a/__tests__/atomEffect.test.ts
+++ b/__tests__/atomEffect.test.ts
@@ -1,4 +1,4 @@
-import { createElement, useEffect } from 'react'
+import { StrictMode, createElement, useEffect } from 'react'
 import {
   act,
   render,
@@ -6,7 +6,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react'
-import { Provider, useAtom, useAtomValue, useSetAtom } from 'jotai/react'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai/react'
 import { atom, createStore, getDefaultStore } from 'jotai/vanilla'
 import { atomEffect } from '../src/atomEffect'
 
@@ -600,7 +600,7 @@ it('should abort the previous promise', async () => {
   expect(completedRuns).toEqual([0, 2])
 })
 
-describe.only('should not run the effect when the effectAtom is unmounted', () => {
+describe('should not run the effect when the effectAtom is unmounted', () => {
   it('[render]', async () => {
     const countAtom = atom(0)
     let runCount = 0
@@ -617,7 +617,7 @@ describe.only('should not run the effect when the effectAtom is unmounted', () =
         children: 'increment',
       })
     }
-    render(createElement(TestComponent, null), { wrapper: Provider })
+    render(createElement(TestComponent, null), { wrapper: StrictMode })
     await delay(0)
     expect(runCount).toBe(1)
     await act(async () => screen.getByText('increment').click())

--- a/__tests__/atomEffect.test.ts
+++ b/__tests__/atomEffect.test.ts
@@ -1,7 +1,13 @@
-import { useEffect } from 'react'
-import { act, renderHook, waitFor } from '@testing-library/react'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai/react'
-import { atom, getDefaultStore } from 'jotai/vanilla'
+import { createElement, useEffect } from 'react'
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from '@testing-library/react'
+import { Provider, useAtom, useAtomValue, useSetAtom } from 'jotai/react'
+import { atom, createStore, getDefaultStore } from 'jotai/vanilla'
 import { atomEffect } from '../src/atomEffect'
 
 it('should run the effect on vanilla store', async () => {
@@ -592,6 +598,67 @@ it('should abort the previous promise', async () => {
   expect(runCount).toBe(3)
   expect(abortedRuns).toEqual([1])
   expect(completedRuns).toEqual([0, 2])
+})
+
+describe.only('should not run the effect when the effectAtom is unmounted', () => {
+  it('[render]', async () => {
+    const countAtom = atom(0)
+    let runCount = 0
+    const effectAtom = atomEffect((get) => {
+      runCount++
+      console.log('[run]', { runCount })
+      get(countAtom)
+    })
+    function TestComponent() {
+      useAtom(effectAtom)
+      const setCount = useSetAtom(countAtom)
+      return createElement('button', {
+        onClick: () => setCount(increment),
+        children: 'increment',
+      })
+    }
+    render(createElement(TestComponent, null), { wrapper: Provider })
+    await delay(0)
+    expect(runCount).toBe(1)
+    await act(async () => screen.getByText('increment').click())
+    expect(runCount).toBe(2)
+  })
+
+  it('[renderHook]', async () => {
+    const countAtom = atom(0)
+    let runCount = 0
+    const effectAtom = atomEffect((get) => {
+      runCount++
+      console.log('[run]', { runCount })
+      get(countAtom)
+    })
+    function useTest() {
+      useAtom(effectAtom)
+      return useSetAtom(countAtom)
+    }
+    const { result } = renderHook(useTest)
+    const setCount = result.current
+    await delay(0)
+    expect(runCount).toBe(1)
+    await act(() => setCount(increment))
+    expect(runCount).toBe(2)
+  })
+
+  it('[unit]', async () => {
+    const countAtom = atom(0)
+    let runCount = 0
+    const effectAtom = atomEffect((get) => {
+      runCount++
+      console.log('[run]', { runCount })
+      get(countAtom)
+    })
+    const store = createStore()
+    store.sub(effectAtom, () => {})
+    await delay(0)
+    expect(runCount).toBe(1)
+    await act(() => store.set(countAtom, increment))
+    expect(runCount).toBe(2)
+  })
 })
 
 function increment(count: number) {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "html-webpack-plugin": "^5.5.3",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "jotai": "^2.4.3",
+    "jotai": "^2.5.0",
     "microbundle": "^0.15.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 devDependencies:
   '@testing-library/react':
     specifier: ^14.0.0
@@ -56,8 +60,8 @@ devDependencies:
     specifier: ^29.7.0
     version: 29.7.0
   jotai:
-    specifier: ^2.4.3
-    version: 2.4.3(@types/react@18.2.25)(react@18.2.0)
+    specifier: ^2.5.0
+    version: 2.5.0(@types/react@18.2.25)(react@18.2.0)
   microbundle:
     specifier: ^0.15.1
     version: 0.15.1
@@ -5864,8 +5868,8 @@ packages:
       - ts-node
     dev: true
 
-  /jotai@2.4.3(@types/react@18.2.25)(react@18.2.0):
-    resolution: {integrity: sha512-CSAHX9LqWG5WCrU8OgBoZbBJ+Bo9rQU0mPusEF4e0CZ/SNFgurG26vb3UpgvCSJZgYVcUQNiUBM5q86PA8rstQ==}
+  /jotai@2.5.0(@types/react@18.2.25)(react@18.2.0):
+    resolution: {integrity: sha512-iPJDFrhNw3KU4o4SSAESeZoW+nM1L/76VULXZWF23qmivBEcbAQjiF5n1W4Hn5dXAol4tmtEYe4HH7d9emEz0Q==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=17.0.0'

--- a/src/atomEffect.ts
+++ b/src/atomEffect.ts
@@ -30,7 +30,6 @@ export function atomEffect(
       ref.cleanup?.()
       ref.cleanup = undefined
       ref.mounted = false
-      ref.promise = undefined
     }
   })
   initAtom.onMount = (init) => {

--- a/src/atomEffect.ts
+++ b/src/atomEffect.ts
@@ -30,6 +30,7 @@ export function atomEffect(
       ref.cleanup?.()
       ref.cleanup = undefined
       ref.mounted = false
+      ref.promise = undefined
     }
   })
   initAtom.onMount = (init) => {


### PR DESCRIPTION
## Summary
With Jotai v2.5.0, atomEffect does not rerun when deps change.

## Related Discussion
https://github.com/pmndrs/jotai/discussions/2218

## Related Issue
https://github.com/jotaijs/jotai-effect/issues/13

## Notes
The behavior is reproducible in https://codesandbox.io/s/relaxed-neco-t7cjyj?file=/src/App.tsx

However, the added tests should fail but do not.

TODO: Understand why these tests pass while codesandbox has the bug.