### PR TITLE
chore: set jotai minimum version to `2.5.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "html-webpack-plugin": "^5.5.3",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "jotai": "^2.5.0",
+    "jotai": "^2.5.1",
     "microbundle": "^0.15.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.3",
@@ -79,6 +79,6 @@
     "webpack-dev-server": "^4.15.1"
   },
   "peerDependencies": {
-    "jotai": ">=2.4.3"
+    "jotai": ">=2.5.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ devDependencies:
     specifier: ^29.7.0
     version: 29.7.0
   jotai:
-    specifier: ^2.5.0
-    version: 2.5.0(@types/react@18.2.25)(react@18.2.0)
+    specifier: ^2.5.1
+    version: 2.5.1(@types/react@18.2.25)(react@18.2.0)
   microbundle:
     specifier: ^0.15.1
     version: 0.15.1
@@ -5868,8 +5868,8 @@ packages:
       - ts-node
     dev: true
 
-  /jotai@2.5.0(@types/react@18.2.25)(react@18.2.0):
-    resolution: {integrity: sha512-iPJDFrhNw3KU4o4SSAESeZoW+nM1L/76VULXZWF23qmivBEcbAQjiF5n1W4Hn5dXAol4tmtEYe4HH7d9emEz0Q==}
+  /jotai@2.5.1(@types/react@18.2.25)(react@18.2.0):
+    resolution: {integrity: sha512-vanPCCSuHczUXNbVh/iUunuMfrWRL4FdBtAbTRmrfqezJcKb8ybBTg8iivyYuUHapjcDETyJe1E4inlo26bVHA==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=17.0.0'


### PR DESCRIPTION
It seems like jotai-effect won't pass the test cases in 2.4.3

```shell
➜  jotai-effect git:(main) ✗ pnpm install jotai@2.4.3
 WARN  deprecated @babel/plugin-proposal-class-properties@7.12.1: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.
 WARN  deprecated rollup-plugin-terser@7.0.2: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
 WARN  deprecated sourcemap-codec@1.4.8: Please use @jridgewell/sourcemap-codec instead
 WARN  deprecated stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
Packages: +1 -1
+-
Progress: resolved 1070, reused 1070, downloaded 0, added 1, done

devDependencies:
- jotai 2.5.1
+ jotai 2.4.3 (2.5.1 is available)

Done in 1.6s
➜  jotai-effect git:(himself65/change-mininum) ✗ pnpm run test           

> jotai-effect@0.2.3 test /Users/himself65/Code/jotai-effect
> run-s eslint tsc-test jest


> jotai-effect@0.2.3 eslint /Users/himself65/Code/jotai-effect
> eslint --ext .js,.ts,.tsx .


> jotai-effect@0.2.3 tsc-test /Users/himself65/Code/jotai-effect
> tsc --project . --noEmit


> jotai-effect@0.2.3 jest /Users/himself65/Code/jotai-effect
> jest

 FAIL  __tests__/atomEffect.test.ts
  ● should run the effect once even if the effect is mounted multiple times

    expect(received).toBe(expected) // Object.is equality

    Expected: 3
    Received: 2

      528 |     setNumbers(increment)
      529 |   })
    > 530 |   expect(runCount).toBe(3)
          |                    ^
      531 | })
      532 |
      533 | it('should abort the previous promise', async () => {

      at Object.<anonymous> (__tests__/atomEffect.test.ts:530:20)

  ● should not run the effect when the effectAtom is unmounted

    expect(received).toBe(expected) // Object.is equality

    Expected: 2
    Received: 1

      618 |   expect(runCount).toBe(1)
      619 |   await act(() => setCount(increment))
    > 620 |   expect(runCount).toBe(2)
          |                    ^
      621 | })
      622 |
      623 | function increment(count: number) {

      at Object.<anonymous> (__tests__/atomEffect.test.ts:620:20)

 FAIL  __tests__/atomEffect.strict.test.ts
  ● should run the effect on mount and cleanup on unmount and whenever countAtom changes

    expect(received).toBe(expected) // Object.is equality

    Expected: 1
    Received: 0

      103 |
      104 |   // changing the value should run the effect again and the previous cleanup
    > 105 |   expect(effect.unmount).toBe(1)
          |                          ^
      106 |   expect(effect.mount).toBe(2)
      107 |
      108 |   await incrementCount()

      at Object.<anonymous> (__tests__/atomEffect.strict.test.ts:105:26)

  ● should run the effect on mount and cleanup on unmount and whenever countAtom changes

    expect.assertions(11)

    Expected eleven assertions to be called but received five assertion calls.

      62 |
      63 | it('should run the effect on mount and cleanup on unmount and whenever countAtom changes', async () => {
    > 64 |   expect.assertions(11)
         |          ^
      65 |   const effect = { mount: 0, unmount: 0 }
      66 |
      67 |   const countAtom = atom(0)

      at Object.<anonymous> (__tests__/atomEffect.strict.test.ts:64:10)

  ● should not cause infinite loops when effect updates the watched atom

    expect(received).toBe(expected) // Object.is equality

    Expected: 2
    Received: 1

      150 |   // changing the value should run the effect again one time
      151 |   await result.current()
    > 152 |   expect(runCount).toBe(2)
          |                    ^
      153 | })
      154 |
      155 | it('should not cause infinite loops when effect updates the watched atom asynchronous', async () => {

      at Object.<anonymous> (__tests__/atomEffect.strict.test.ts:152:20)

  ● should not cause infinite loops when effect updates the watched atom asynchronous

    expect(received).toBe(expected) // Object.is equality

    Expected: 2
    Received: 1

      177 |   await result.current()
      178 |   await delay(0)
    > 179 |   expect(runCount).toBe(2)
          |                    ^
      180 | })
      181 |
      182 | it('should conditionally run the effect and cleanup when effectAtom is unmounted', async () => {

      at Object.<anonymous> (__tests__/atomEffect.strict.test.ts:179:20)

  ● should correctly process synchronous updates to the same atom › should correctly process synchronous updates when effectIncrementCountBy is 0 and incrementCountBy is 1

    expect(received).toBe(expected) // Object.is equality

    Expected: 2
    Received: 1

      395 |       expect(result.current.count).toBe(after.resultCount)
      396 |
    > 397 |       expect(runCount.current).toBe(after.runCount)
          |                                ^
      398 |     }
      399 |   )
      400 | })

      at __tests__/atomEffect.strict.test.ts:397:32

  ● should correctly process synchronous updates to the same atom › should correctly process synchronous updates when effectIncrementCountBy is 0 and incrementCountBy is 2

    expect(received).toBe(expected) // Object.is equality

    Expected: 2
    Received: 1

      395 |       expect(result.current.count).toBe(after.resultCount)
      396 |
    > 397 |       expect(runCount.current).toBe(after.runCount)
          |                                ^
      398 |     }
      399 |   )
      400 | })

      at __tests__/atomEffect.strict.test.ts:397:32

  ● should correctly process synchronous updates to the same atom › should correctly process synchronous updates when effectIncrementCountBy is 1 and incrementCountBy is 1

    expect(received).toBe(expected) // Object.is equality

    Expected: 3
    Received: 2

      393 |
      394 |       // final value after synchronous updates and rerun of the effect
    > 395 |       expect(result.current.count).toBe(after.resultCount)
          |                                    ^
      396 |
      397 |       expect(runCount.current).toBe(after.runCount)
      398 |     }

      at __tests__/atomEffect.strict.test.ts:395:36

  ● should correctly process synchronous updates to the same atom › should correctly process synchronous updates when effectIncrementCountBy is 1 and incrementCountBy is 1

    expect.assertions(3)

    Expected three assertions to be called but received two assertion calls.

      375 |     'should correctly process synchronous updates when effectIncrementCountBy is $effectIncrementCountBy and incrementCountBy is $incrementCountBy',
      376 |     async ({ effectIncrementCountBy, incrementCountBy, runs }) => {
    > 377 |       expect.assertions(3)
          |              ^
      378 |       const { result, runCount } = setup({
      379 |         effectIncrementCountBy,
      380 |         incrementCountBy,

      at __tests__/atomEffect.strict.test.ts:377:14

  ● should correctly process synchronous updates to the same atom › should correctly process synchronous updates when effectIncrementCountBy is 1 and incrementCountBy is 2

    expect(received).toBe(expected) // Object.is equality

    Expected: 4
    Received: 3

      393 |
      394 |       // final value after synchronous updates and rerun of the effect
    > 395 |       expect(result.current.count).toBe(after.resultCount)
          |                                    ^
      396 |
      397 |       expect(runCount.current).toBe(after.runCount)
      398 |     }

      at __tests__/atomEffect.strict.test.ts:395:36

  ● should correctly process synchronous updates to the same atom › should correctly process synchronous updates when effectIncrementCountBy is 1 and incrementCountBy is 2

    expect.assertions(3)

    Expected three assertions to be called but received two assertion calls.

      375 |     'should correctly process synchronous updates when effectIncrementCountBy is $effectIncrementCountBy and incrementCountBy is $incrementCountBy',
      376 |     async ({ effectIncrementCountBy, incrementCountBy, runs }) => {
    > 377 |       expect.assertions(3)
          |              ^
      378 |       const { result, runCount } = setup({
      379 |         effectIncrementCountBy,
      380 |         incrementCountBy,

      at __tests__/atomEffect.strict.test.ts:377:14

  ● should correctly process synchronous updates to the same atom › should correctly process synchronous updates when effectIncrementCountBy is 2 and incrementCountBy is 1

    expect(received).toBe(expected) // Object.is equality

    Expected: 5
    Received: 3

      393 |
      394 |       // final value after synchronous updates and rerun of the effect
    > 395 |       expect(result.current.count).toBe(after.resultCount)
          |                                    ^
      396 |
      397 |       expect(runCount.current).toBe(after.runCount)
      398 |     }

      at __tests__/atomEffect.strict.test.ts:395:36

  ● should correctly process synchronous updates to the same atom › should correctly process synchronous updates when effectIncrementCountBy is 2 and incrementCountBy is 1

    expect.assertions(3)

    Expected three assertions to be called but received two assertion calls.

      375 |     'should correctly process synchronous updates when effectIncrementCountBy is $effectIncrementCountBy and incrementCountBy is $incrementCountBy',
      376 |     async ({ effectIncrementCountBy, incrementCountBy, runs }) => {
    > 377 |       expect.assertions(3)
          |              ^
      378 |       const { result, runCount } = setup({
      379 |         effectIncrementCountBy,
      380 |         incrementCountBy,

      at __tests__/atomEffect.strict.test.ts:377:14

  ● should correctly process synchronous updates to the same atom › should correctly process synchronous updates when effectIncrementCountBy is 2 and incrementCountBy is 2

    expect(received).toBe(expected) // Object.is equality

    Expected: 6
    Received: 4

      393 |
      394 |       // final value after synchronous updates and rerun of the effect
    > 395 |       expect(result.current.count).toBe(after.resultCount)
          |                                    ^
      396 |
      397 |       expect(runCount.current).toBe(after.runCount)
      398 |     }

      at __tests__/atomEffect.strict.test.ts:395:36

  ● should correctly process synchronous updates to the same atom › should correctly process synchronous updates when effectIncrementCountBy is 2 and incrementCountBy is 2

    expect.assertions(3)

    Expected three assertions to be called but received two assertion calls.

      375 |     'should correctly process synchronous updates when effectIncrementCountBy is $effectIncrementCountBy and incrementCountBy is $incrementCountBy',
      376 |     async ({ effectIncrementCountBy, incrementCountBy, runs }) => {
    > 377 |       expect.assertions(3)
          |              ^
      378 |       const { result, runCount } = setup({
      379 |         effectIncrementCountBy,
      380 |         incrementCountBy,

      at __tests__/atomEffect.strict.test.ts:377:14

  ● should not batch effect setStates

    expect(received).toBe(expected) // Object.is equality

    Expected: 2
    Received: 0

      428 |
      429 |   await act(async () => setTrigger((x) => !x))
    > 430 |   expect(valueResult.current).toBe(2)
          |                               ^
      431 |   expect(runCount.current).toBe(3) // <--- not batched (we would expect runCount to be 2 if batched)
      432 | })
      433 |

      at Object.<anonymous> (__tests__/atomEffect.strict.test.ts:430:31)

  ● should not batch effect setStates

    expect.assertions(4)

    Expected four assertions to be called but received three assertion calls.

      401 |
      402 | it('should not batch effect setStates', async () => {
    > 403 |   expect.assertions(4)
          |          ^
      404 |   const valueAtom = atom(0)
      405 |   const runCount = { current: 0 }
      406 |   const derivedAtom = atom((get) => {

      at Object.<anonymous> (__tests__/atomEffect.strict.test.ts:403:10)

  ● should batch synchronous updates as a single transaction

    expect(received).toBe(expected) // Object.is equality

    Expected: 2
    Received: 1

      466 |     setNumbers(increment)
      467 |   })
    > 468 |   expect(runCount).toBe(2)
          |                    ^
      469 |   expect(result.current.lettersAndNumbers).toEqual(['a0', 'b1'])
      470 | })
      471 |

      at Object.<anonymous> (__tests__/atomEffect.strict.test.ts:468:20)

  ● should batch synchronous updates as a single transaction

    expect.assertions(4)

    Expected four assertions to be called but received three assertion calls.

      433 |
      434 | it('should batch synchronous updates as a single transaction', async () => {
    > 435 |   expect.assertions(4)
          |          ^
      436 |   const lettersAtom = atom('a')
      437 |   lettersAtom.debugLabel = 'lettersAtom'
      438 |   const numbersAtom = atom(0)

      at Object.<anonymous> (__tests__/atomEffect.strict.test.ts:435:10)

  ● should run the effect once even if the effect is mounted multiple times

    expect(received).toBe(expected) // Object.is equality

    Expected: 2
    Received: 1

      517 |     setNumbers(increment)
      518 |   })
    > 519 |   expect(runCount).toBe(2)
          |                    ^
      520 |   await act(async () => {
      521 |     setLetters(incrementLetter)
      522 |     setNumbers(increment)

      at Object.<anonymous> (__tests__/atomEffect.strict.test.ts:519:20)

  ● should run the effect once even if the effect is mounted multiple times

    expect.assertions(3)

    Expected three assertions to be called but received two assertion calls.

      471 |
      472 | it('should run the effect once even if the effect is mounted multiple times', async () => {
    > 473 |   expect.assertions(3)
          |          ^
      474 |   const lettersAtom = atom('a')
      475 |   lettersAtom.debugLabel = 'lettersAtom'
      476 |   const numbersAtom = atom(0)

      at Object.<anonymous> (__tests__/atomEffect.strict.test.ts:473:10)

  ● should abort the previous promise

    expect(received).toBe(expected) // Object.is equality

    Expected: 2
    Received: 1

      580 |
      581 |   await act(async () => setCount(increment))
    > 582 |   expect(runCount).toBe(2)
          |                    ^
      583 |   expect(abortedRuns).toEqual([])
      584 |   expect(completedRuns).toEqual([0])
      585 |

      at Object.<anonymous> (__tests__/atomEffect.strict.test.ts:582:20)

Test Suites: 2 failed, 2 total
Tests:       15 failed, 25 passed, 40 total
Snapshots:   0 total
Time:        2.296 s
Ran all test suites.
 ELIFECYCLE  Command failed with exit code 1.
ERROR: "jest" exited with 1.
 ELIFECYCLE  Test failed. See above for more details.
```