### PR TITLE
feat: allow async infinite loops

### DIFF
--- a/__tests__/atomEffect.strict.test.ts
+++ b/__tests__/atomEffect.strict.test.ts
@@ -160,23 +160,16 @@ it('should not cause infinite loops when effect updates the watched atom asynchr
     get(watchedAtom)
     runCount++
     setTimeout(() => {
-      set(watchedAtom, get(watchedAtom) + 1)
+      set(watchedAtom, increment)
     }, 0)
   })
   function useTest() {
     useAtom(effectAtom)
-    const setCount = useSetAtom(watchedAtom)
-    return () => act(async () => setCount(increment))
   }
-  const { result } = renderHook(useTest, { wrapper: StrictMode })
-  await delay(0)
+  renderHook(useTest, { wrapper })
   // initial render should run the effect once
-  await waitFor(() => assert(runCount === 1))
-
-  // changing the value should run the effect again one time
-  await result.current()
-  await delay(0)
-  expect(runCount).toBe(2)
+  await waitFor(() => assert(runCount >= 2))
+  expect(runCount).toBeGreaterThanOrEqual(2)
 })
 
 it('should conditionally run the effect and cleanup when effectAtom is unmounted', async () => {

--- a/__tests__/atomEffect.test.ts
+++ b/__tests__/atomEffect.test.ts
@@ -160,7 +160,7 @@ it('should not cause infinite loops when effect updates the watched atom', async
   expect(runCount).toBe(2)
 })
 
-it('should not cause infinite loops when effect updates the watched atom asynchronous', async () => {
+it('should cause infinite loops when effect updates the watched atom asynchronous', async () => {
   expect.assertions(1)
   const watchedAtom = atom(0)
   let runCount = 0
@@ -168,23 +168,13 @@ it('should not cause infinite loops when effect updates the watched atom asynchr
     get(watchedAtom)
     runCount++
     setTimeout(() => {
-      set(watchedAtom, get(watchedAtom) + 1)
+      set(watchedAtom, increment)
     }, 0)
   })
-  function useTest() {
-    useAtom(effectAtom)
-    const setCount = useSetAtom(watchedAtom)
-    return () => act(async () => setCount(increment))
-  }
-  const { result } = renderHook(useTest)
-  await delay(0)
-  // initial render should run the effect once
-  await waitFor(() => assert(runCount === 1))
-
-  // changing the value should run the effect again one time
-  await result.current()
-  await delay(0)
-  expect(runCount).toBe(2)
+  const store = getDefaultStore()
+  store.sub(effectAtom, () => void 0)
+  await waitFor(() => assert(runCount >= 2))
+  expect(runCount).toBeGreaterThanOrEqual(2)
 })
 
 it('should conditionally run the effect and cleanup when effectAtom is unmounted', async () => {

--- a/src/atomEffect.ts
+++ b/src/atomEffect.ts
@@ -64,15 +64,7 @@ export function atomEffect(
         }
       }))
     },
-    (get, set, ...args: Parameters<Setter>) => {
-      const ref = get(refAtom)
-      ++ref.inProgress
-      try {
-        return set(...args)
-      } finally {
-        --ref.inProgress
-      }
-    }
+    (_get, set, ...args: Parameters<Setter>) => set(...args)
   )
   if (process.env.NODE_ENV !== 'production') {
     effectAtom.debugPrivate = true


### PR DESCRIPTION
Related Discussion: https://github.com/jotaijs/jotai-effect/discussions/16

This PR proposes a simple change to allow infinite loops for asynchronous functions in atomEffect.

Example: The following code will increment count every 1 seconds.
```ts
atomEffect((get, set) => {
  get(countAtom)
  setTimeout(() => {
   set(countAtom, increment) // infinite loops
  }, 1000)
})
```

Refs: https://github.com/jotaijs/jotai-effect/issues/26