### PR TITLE
Recurse

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ yarn add jotai-effect
 ```ts
 type CleanupFn = () => void
 
-type EffectFn = (get: Getter, set: Setter) => CleanupFn | void
+type EffectFn = (get: Getter, set: Setter & { recurse: Setter }) => CleanupFn | void
 
 function atomEffect(effectFn: EffectFn): Atom<void>
 ```
@@ -90,7 +90,7 @@ function MyComponent() {
   </details>
 
 - **Resistent To Infinite Loops:**
-  `atomEffect` does not rerun when it changes a value that it is watching.
+  `atomEffect` does not rerun when it changes a value that it is watching with `set`.
 
   <!-- prettier-ignore -->
   <details style="cursor: pointer; user-select: none;">
@@ -102,6 +102,24 @@ function MyComponent() {
     // this will not infinite loop
     get(countAtom) // after mount, count will be 1
     set(countAtom, increment)
+  })
+  ```
+- **Supports Recursion:**
+  Recursion is supported with `set.recurse` for both sync and async use cases, but is not supported in the cleanup function.
+
+  <!-- prettier-ignore -->
+  <details style="cursor: pointer; user-select: none;">
+    <summary>Example</summary>
+
+  ```js
+  const countAtom = atom(0)
+  atomEffect((get, set) => {
+    // increments count once per second
+    const count = get(countAtom)
+    const timeoutId = setTimeout(() => {
+      set.recurse(countAtom, increment)
+    }, 1000)
+    return () => clearTimeout(timeoutId)
   })
   ```
 

--- a/src/atomEffect.ts
+++ b/src/atomEffect.ts
@@ -1,30 +1,40 @@
-import type { Getter, Setter } from 'jotai/vanilla'
+import type { Atom, Getter, Setter } from 'jotai/vanilla'
 import { atom } from 'jotai/vanilla'
 
 type CleanupFn = () => void
 
+type SetterWithRecurse = Setter & { recurse: Setter }
+
 export function atomEffect(
-  effectFn: (get: Getter, set: Setter) => void | CleanupFn
+  effectFn: (get: Getter, set: SetterWithRecurse) => void | CleanupFn
 ) {
   const refAtom = atom(() => ({
     mounted: false,
     inProgress: 0,
     promise: undefined as Promise<void> | undefined,
     cleanup: undefined as CleanupFn | void,
+    fromCleanup: false,
+    recursing: false,
+    refresh: () => {},
+    refreshing: false,
+    set: (() => {}) as Setter,
   }))
-  if (process.env.NODE_ENV !== 'production') {
-    refAtom.debugPrivate = true
-  }
 
   const refreshAtom = atom(0)
-  if (process.env.NODE_ENV !== 'production') {
-    refreshAtom.debugPrivate = true
-  }
 
   const initAtom = atom(null, (get, set, mounted: boolean) => {
     const ref = get(refAtom)
     ref.mounted = mounted
     if (mounted) {
+      ref.set = set
+      ref.refresh = () => {
+        try {
+          ref.refreshing = true
+          set(refreshAtom, (c) => c + 1)
+        } finally {
+          ref.refreshing = false
+        }
+      }
       set(refreshAtom, (c) => c + 1)
     } else {
       ref.cleanup?.()
@@ -35,40 +45,67 @@ export function atomEffect(
     init(true)
     return () => init(false)
   }
-  if (process.env.NODE_ENV !== 'production') {
-    initAtom.debugPrivate = true
-  }
-
-  const effectAtom = atom(
-    (get, { setSelf }) => {
-      get(refreshAtom)
-      const ref = get(refAtom)
-      if (!ref.mounted || ref.inProgress) {
-        return ref.promise
-      }
-      ++ref.inProgress
-      return (ref.promise = Promise.resolve().then(() => {
-        try {
-          if (!ref.mounted) return
-          ref.cleanup?.()
-          ref.cleanup = effectFn(get, setSelf as Setter)
-        } finally {
-          --ref.inProgress
-          ref.promise = undefined
-        }
-      }))
-    },
-    (get, set, ...args: Parameters<Setter>) => {
-      const ref = get(refAtom)
-      ++ref.inProgress
+  const effectAtom = atom((get) => {
+    get(refreshAtom)
+    const ref = get(refAtom)
+    if (!ref.mounted || ref.recursing || (ref.inProgress && !ref.refreshing)) {
+      return ref.promise
+    }
+    const currDeps = new Map<Atom<unknown>, unknown>()
+    const getter: Getter = (a) => {
+      const value = get(a)
+      currDeps.set(a, value)
+      return value
+    }
+    const setter: SetterWithRecurse = (...args) => {
       try {
-        return set(...args)
+        ++ref.inProgress
+        return ref.set(...args)
       } finally {
         --ref.inProgress
       }
     }
-  )
+    setter.recurse = (anAtom, ...args) => {
+      if (ref.fromCleanup) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn('cannot recurse inside cleanup')
+        }
+        return undefined as any
+      }
+      try {
+        ref.recursing = true
+        return ref.set(anAtom, ...args)
+      } finally {
+        ref.recursing = false
+        const depsChanged = Array.from(currDeps).some(([a, v]) => get(a) !== v)
+        if (depsChanged) ref.refresh()
+      }
+    }
+    ++ref.inProgress
+    const effector = () => {
+      try {
+        ref.refreshing = false
+        if (!ref.mounted) return
+        try {
+          ref.fromCleanup = true
+          ref.cleanup?.()
+        } finally {
+          ref.fromCleanup = false
+        }
+        ref.cleanup = effectFn(getter, setter)
+      } finally {
+        ref.promise = undefined
+        --ref.inProgress
+      }
+    }
+    return ref.refreshing
+      ? effector()
+      : (ref.promise = Promise.resolve().then(effector))
+  })
   if (process.env.NODE_ENV !== 'production') {
+    refAtom.debugPrivate = true
+    refreshAtom.debugPrivate = true
+    initAtom.debugPrivate = true
     effectAtom.debugPrivate = true
   }
 


### PR DESCRIPTION
Related Issue: https://github.com/jotaijs/jotai-effect/issues/26
Related Discussion: https://github.com/jotaijs/jotai-effect/discussions/16

This PR introduces additional api that allows the developer to opt-in for recursion.

```ts
type SetterWithRecurse = Setter && { recurse: Setter }
type EffectFn = (get: Getter, set: SetterWithRecurse) => CleanupFn
```

✅ Synchronous recursive loops
```ts
const effect = atomEffect((get, set) => {
  const count = get(countAtom)
  if (count < 5) {
    set.recurse(countAtom, increment)
  }
})
store.sub(effect, () => void 0)
await delay(0)
store.get(countAtom) // 5
```

✅ Asynchronous recursive loops. Both task and microtask delay is supported.
```ts
atomEffect((get, { recurse }) => {
  const count = get(countAtom)
  if (count < 5) {
    Promise.resolve().then(() => {
      recurse(countAtom, increment)
    })
  }
})
store.sub(effect, () => void 0)
await delay(0)
store.get(countAtom) // 5
```

❌ Synchronous recursive loops in callback are disallowed (with warning)
```ts
atomEffect((get, set) => {
  get(countAtom)
  return () => {
    set.recurse(countAtom, increment)
  }
})
```

