### PR TITLE
feat: get.peek reads atom value without subscribing to updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm i jotai-effect
 type CleanupFn = () => void
 
 type EffectFn = (
-  get: Getter,
+  get: Getter & { peek: Getter },
   set: Setter & { recurse: Setter },
 ) => CleanupFn | void
 
@@ -126,6 +126,23 @@ function MyComponent() {
       set.recurse(countAtom, increment)
     }, 1000)
     return () => clearTimeout(timeoutId)
+  })
+  ```
+
+  </details>
+
+- **Supports Peek:**
+  Read atom data without subscribing to changes with `get.peek`.
+
+  <!-- prettier-ignore -->
+  <details style="cursor: pointer; user-select: none;">
+    <summary>Example</summary>
+
+  ```js
+  const countAtom = atom(0)
+  atomEffect((get, set) => {
+    // will not rerun when countAtom changes
+    const count = get.peek(countAtom)
   })
   ```
 

--- a/__tests__/atomEffect.test.ts
+++ b/__tests__/atomEffect.test.ts
@@ -876,6 +876,22 @@ it.skip('should not infinite loop with nested atomEffects', async () => {
   })
 })
 
+it('should not rerun with get.peek', async () => {
+  expect.assertions(1)
+  const countAtom = atom(0)
+  let runCount = 0
+  const effectAtom = atomEffect((get) => {
+    get.peek(countAtom)
+    runCount++
+  })
+  const store = getDefaultStore()
+  store.sub(effectAtom, () => void 0)
+  await waitFor(() => assert(runCount === 1))
+  store.set(countAtom, increment)
+  await delay(0)
+  expect(runCount).toBe(1)
+})
+
 function increment(count: number) {
   return count + 1
 }

--- a/src/atomEffect.ts
+++ b/src/atomEffect.ts
@@ -67,9 +67,7 @@ export function atomEffect(
       currDeps.set(a, value)
       return value
     }
-    getter.peek = (anAtom) => {
-      return ref.get(anAtom)
-    }
+    getter.peek = (anAtom) => ref.get(anAtom)
     const setter: SetterWithRecurse = (...args) => {
       try {
         ++ref.inProgress

--- a/src/atomEffect.ts
+++ b/src/atomEffect.ts
@@ -2,11 +2,11 @@ import type { Atom, Getter, Setter } from 'jotai/vanilla'
 import { atom } from 'jotai/vanilla'
 
 type CleanupFn = () => void
-
+type GetterWithPeek = Getter & { peek: Getter }
 type SetterWithRecurse = Setter & { recurse: Setter }
 
 export function atomEffect(
-  effectFn: (get: Getter, set: SetterWithRecurse) => void | CleanupFn
+  effectFn: (get: GetterWithPeek, set: SetterWithRecurse) => void | CleanupFn
 ) {
   const refAtom = atom(() => ({
     mounted: false,
@@ -17,6 +17,7 @@ export function atomEffect(
     recursing: false,
     refresh: () => {},
     refreshing: false,
+    get: (() => {}) as Getter,
     set: (() => {}) as Setter,
   }))
 
@@ -26,6 +27,7 @@ export function atomEffect(
     const ref = get(refAtom)
     ref.mounted = mounted
     if (mounted) {
+      ref.get = get
       ref.set = set
       ref.refresh = () => {
         try {
@@ -60,10 +62,13 @@ export function atomEffect(
       return ref.promise
     }
     const currDeps = new Map<Atom<unknown>, unknown>()
-    const getter: Getter = (a) => {
+    const getter: GetterWithPeek = (a) => {
       const value = get(a)
       currDeps.set(a, value)
       return value
+    }
+    getter.peek = (anAtom) => {
+      return ref.get(anAtom)
     }
     const setter: SetterWithRecurse = (...args) => {
       try {


### PR DESCRIPTION
## Overview
This PR introduces a new method, `get.peek`. With `get.peek` atomEffect can read an atom's value without subscribing to its updates.

This can be beneficial if you only need the current value at a specific moment in time and do not need updates.

## Updated Type Signature
```ts
type CleanupFn = () => void

type EffectFn = (
  get: Getter & { peek: Getter },
  set: Setter & { recurse: Setter },
) => CleanupFn | void

declare function atomEffect(effectFn: EffectFn): Atom<void>
```

## Example Usage
Read atom data without subscribing to changes with `get.peek`.
  ```js
  const countAtom = atom(0)
  atomEffect((get, set) => {
    // will not rerun when countAtom changes
    const count = get.peek(countAtom)
  })
  ```