### PR TITLE
AtomEffect supports recursion under jotai store2

### DIFF
--- a/src/atomEffect.ts
+++ b/src/atomEffect.ts
@@ -75,6 +75,7 @@ export function atomEffect(
         ++ref.inProgress
         return ref.set(...args)
       } finally {
+        Array.from(currDeps.keys(), get)
         --ref.inProgress
       }
     }


### PR DESCRIPTION
## Context
The new jotai store implementation introduced as part of 2.9.0 has a subtle change to functionality. Atom dependencies are not preserved after recursive recomputations. Instead each recursive iteration overwrites the current dependents.

## Hack
This PR introduces a quick fix by "reminding" jotai, of the current dependents synchronous after set is called.

```diff
 const setter: SetterWithRecurse = (...args) => {
   try {
     ++ref.inProgress
     return ref.set(...args)
   } finally {
+     Array.from(currDeps.keys(), get)
     --ref.inProgress
   }
 }
```