### PR TITLE
atomEffect should not suspend the component

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -75,6 +75,7 @@
         "pathGroupsExcludedImportTypes": ["builtin"]
       }
     ],
+    "no-inner-declarations": "off",
     "react/jsx-uses-react": "off",
     "react/react-in-jsx-scope": "off",
     "sort-imports": [


### PR DESCRIPTION
## Related
https://github.com/jotaijs/jotai-effect/issues/44

## Summary
A recent change to atomEffect caused the internal promise to be returned. This caused the consuming React component to suspend.

### PR Includes
- failing test
- fix
