### PR TITLE
feat: effect atoms expose their effects via an effect property

### DIFF
--- a/src/withAtomEffect.ts
+++ b/src/withAtomEffect.ts
@@ -1,14 +1,15 @@
-import type { Atom, WritableAtom } from 'jotai/vanilla'
+import { type Atom, type WritableAtom } from 'jotai/vanilla'
 import { atomEffect } from './atomEffect'
+import type { AtomWithEffect, Effect } from './atomEffect'
 
-type Effect = Parameters<typeof atomEffect>[0]
-
-export function withAtomEffect<T extends Atom<any>>(
+export function withAtomEffect<T extends Atom<unknown>>(
   targetAtom: T,
   effect: Effect
-): T {
+): AtomWithEffect<T> {
   const effectAtom = atomEffect(effect)
-  const descriptors = Object.getOwnPropertyDescriptors(targetAtom)
+  const descriptors = Object.getOwnPropertyDescriptors(
+    targetAtom as AtomWithEffect<T>
+  )
   descriptors.read.value = (get, options) => {
     try {
       return targetAtom.read(get, options)
@@ -21,6 +22,14 @@ export function withAtomEffect<T extends Atom<any>>(
       targetAtom as T & WritableAtom<unknown, unknown[], unknown>
     ).write.bind(targetAtom)
   }
+  descriptors.effect = {
+    get() {
+      return effectAtom.effect
+    },
+    set(newEffect) {
+      effectAtom.effect = newEffect
+    },
+  } as typeof descriptors.effect
   // avoid reading `init` to preserve lazy initialization
   return Object.create(Object.getPrototypeOf(targetAtom), descriptors)
 }


### PR DESCRIPTION
## Summary
atomEffects now expose their effect via an `effect` property. You can update their effect at any time by overwriting this property.

```ts
const countWithEffect = withAtomEffect(atom(0), (get) => {
  console.log('count changed')
})
store.sub(countWithEffect, () => {})
store.set(countWithEffect, v => v + 1) // logs "count changed"

// change the effect (NEW)
countWithEffect.effect = () => {
  console.log('count is now', get(countWithEffect))
}
store.set(countWithEffect, v => v + 1) // logs "count is now 1"
```