### PR TITLE
feat: observe api for observing stores with effects

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2662,7 +2662,6 @@ packages:
       es-object-atoms: 1.1.1
       has-property-descriptors: 1.0.2
     dev: true
-
   /string.prototype.trimend@1.0.9:
     resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
     engines: {node: '>= 0.4'}
@@ -2672,7 +2671,6 @@ packages:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
     dev: true
-
   /string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
@@ -2681,29 +2679,24 @@ packages:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
     dev: true
-
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
     dev: true
-
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
     dev: true
-
   /supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
     dev: true
-
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
     dev: true
-
   /synckit@0.9.2:
     resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -2711,7 +2704,6 @@ packages:
       '@pkgr/core': 0.1.1
       tslib: 2.8.1
     dev: true
-
   /tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
@@ -2739,14 +2731,12 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
     dev: true
-
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
     dev: true
-
   /ts-api-utils@2.0.0(typescript@5.7.3):
     resolution: {integrity: sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==}
     engines: {node: '>=18.12'}
@@ -2755,7 +2745,6 @@ packages:
     dependencies:
       typescript: 5.7.3
     dev: true
-
   /tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
     dependencies:
@@ -2775,7 +2764,6 @@ packages:
     dependencies:
       prelude-ls: 1.2.1
     dev: true
-
   /typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -2784,7 +2772,6 @@ packages:
       es-errors: 1.3.0
       is-typed-array: 1.1.15
     dev: true
-
   /typed-array-byte-length@1.0.3:
     resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
     engines: {node: '>= 0.4'}
@@ -2795,7 +2782,6 @@ packages:
       has-proto: 1.2.0
       is-typed-array: 1.1.15
     dev: true
-
   /typed-array-byte-offset@1.0.4:
     resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
     engines: {node: '>= 0.4'}
@@ -2808,7 +2794,6 @@ packages:
       is-typed-array: 1.1.15
       reflect.getprototypeof: 1.0.10
     dev: true
-
   /typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
@@ -2842,7 +2827,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
-
   /unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -3006,12 +2990,10 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
     dev: true
-
   /whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
     dev: true
-
   /which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -3022,7 +3004,6 @@ packages:
       is-string: 1.1.1
       is-symbol: 1.1.1
     dev: true
-
   /which-builtin-type@1.2.1:
     resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
     engines: {node: '>= 0.4'}
@@ -3041,7 +3022,6 @@ packages:
       which-collection: 1.0.2
       which-typed-array: 1.1.18
     dev: true
-
   /which-collection@1.0.2:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
@@ -3051,7 +3031,6 @@ packages:
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
     dev: true
-
   /which-typed-array@1.1.18:
     resolution: {integrity: sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==}
     engines: {node: '>= 0.4'}
@@ -3063,7 +3042,6 @@ packages:
       gopd: 1.2.0
       has-tostringtag: 1.0.2
     dev: true
-
   /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -3071,7 +3049,6 @@ packages:
     dependencies:
       isexe: 2.0.0
     dev: true
-
   /why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -3080,12 +3057,10 @@ packages:
       siginfo: 2.0.0
       stackback: 0.0.2
     dev: true
-
   /word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
     dev: true
-
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2662,6 +2662,7 @@ packages:
       es-object-atoms: 1.1.1
       has-property-descriptors: 1.0.2
     dev: true
+
   /string.prototype.trimend@1.0.9:
     resolution: {integrity: sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==}
     engines: {node: '>= 0.4'}
@@ -2671,6 +2672,7 @@ packages:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
     dev: true
+
   /string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
@@ -2679,24 +2681,29 @@ packages:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
     dev: true
+
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
     dev: true
+
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
     dev: true
+
   /supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
     dev: true
+
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
     dev: true
+
   /synckit@0.9.2:
     resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -2704,6 +2711,7 @@ packages:
       '@pkgr/core': 0.1.1
       tslib: 2.8.1
     dev: true
+
   /tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
@@ -2731,12 +2739,14 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
     dev: true
+
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
     dev: true
+
   /ts-api-utils@2.0.0(typescript@5.7.3):
     resolution: {integrity: sha512-xCt/TOAc+EOHS1XPnijD3/yzpH6qg2xppZO1YDqGoVsNXfQfzHpOdNuXwrwOU8u4ITXJyDCTyt8w5g1sZv9ynQ==}
     engines: {node: '>=18.12'}
@@ -2745,6 +2755,7 @@ packages:
     dependencies:
       typescript: 5.7.3
     dev: true
+
   /tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
     dependencies:
@@ -2764,6 +2775,7 @@ packages:
     dependencies:
       prelude-ls: 1.2.1
     dev: true
+
   /typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -2772,6 +2784,7 @@ packages:
       es-errors: 1.3.0
       is-typed-array: 1.1.15
     dev: true
+
   /typed-array-byte-length@1.0.3:
     resolution: {integrity: sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==}
     engines: {node: '>= 0.4'}
@@ -2782,6 +2795,7 @@ packages:
       has-proto: 1.2.0
       is-typed-array: 1.1.15
     dev: true
+
   /typed-array-byte-offset@1.0.4:
     resolution: {integrity: sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==}
     engines: {node: '>= 0.4'}
@@ -2794,6 +2808,7 @@ packages:
       is-typed-array: 1.1.15
       reflect.getprototypeof: 1.0.10
     dev: true
+
   /typed-array-length@1.0.7:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
@@ -2827,6 +2842,7 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
+
   /unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
@@ -2990,10 +3006,12 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
     dev: true
+
   /whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
     dev: true
+
   /which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -3004,6 +3022,7 @@ packages:
       is-string: 1.1.1
       is-symbol: 1.1.1
     dev: true
+
   /which-builtin-type@1.2.1:
     resolution: {integrity: sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==}
     engines: {node: '>= 0.4'}
@@ -3022,6 +3041,7 @@ packages:
       which-collection: 1.0.2
       which-typed-array: 1.1.18
     dev: true
+
   /which-collection@1.0.2:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
@@ -3031,6 +3051,7 @@ packages:
       is-weakmap: 2.0.2
       is-weakset: 2.0.4
     dev: true
+
   /which-typed-array@1.1.18:
     resolution: {integrity: sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==}
     engines: {node: '>= 0.4'}
@@ -3042,6 +3063,7 @@ packages:
       gopd: 1.2.0
       has-tostringtag: 1.0.2
     dev: true
+
   /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -3049,6 +3071,7 @@ packages:
     dependencies:
       isexe: 2.0.0
     dev: true
+
   /why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -3057,10 +3080,12 @@ packages:
       siginfo: 2.0.0
       stackback: 0.0.2
     dev: true
+
   /word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
     dev: true
+
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}

--- a/src/observe.ts
+++ b/src/observe.ts
@@ -1,0 +1,32 @@
+import { getDefaultStore } from 'jotai/vanilla'
+import { Effect, atomEffect } from './atomEffect'
+
+type Store = ReturnType<typeof getDefaultStore>
+type Unobserve = () => void
+
+const storeEffects = new WeakMap<Store, Map<Effect, Unobserve>>()
+
+export function observe(
+  effect: Effect,
+  store: Store = getDefaultStore()
+): Unobserve {
+  if (!storeEffects.has(store)) {
+    storeEffects.set(store, new Map<Effect, Unobserve>())
+  }
+  const effectSubscriptions = storeEffects.get(store)!
+  if (!effectSubscriptions.has(effect)) {
+    const unsubscribe = store.sub(atomEffect(effect), () => void 0)
+    effectSubscriptions.set(effect, unsubscribe)
+  }
+  return function unobserve() {
+    const effectSubscriptions = storeEffects.get(store)
+    const unsubscribe = effectSubscriptions?.get(effect)
+    if (unsubscribe) {
+      effectSubscriptions!.delete(effect)
+      if (effectSubscriptions!.size === 0) {
+        storeEffects.delete(store)
+      }
+      unsubscribe()
+    }
+  }
+}

--- a/tests/observe.test.ts
+++ b/tests/observe.test.ts
@@ -1,0 +1,179 @@
+import { Getter, atom, createStore, getDefaultStore } from 'jotai/vanilla'
+import { describe, expect, it } from 'vitest'
+import { observe } from '../src/observe'
+import { delay, increment } from './test-utils'
+
+describe('observe', () => {
+  it('should run effect on subscription and cleanup on unsubscribe', async () => {
+    const countAtom = atom(0)
+    let mounted = 0
+
+    const unsubscribe = observe((get, _set) => {
+      mounted++
+      get(countAtom)
+      return () => {
+        mounted--
+      }
+    })
+
+    await delay(0)
+    expect(mounted).toBe(1)
+    unsubscribe()
+    expect(mounted).toBe(0)
+  })
+
+  it('should reuse existing subscription for the same effect', async () => {
+    const countAtom = atom(0)
+    let runCount = 0
+
+    const effect = (get: any) => {
+      runCount++
+      get(countAtom)
+    }
+    const store = getDefaultStore()
+
+    const unsubscribe1 = observe(effect, store)
+    const unsubscribe2 = observe(effect, store)
+
+    await delay(0)
+    expect(runCount).toBe(1)
+
+    store.set(countAtom, increment)
+    await delay(0)
+    expect(runCount).toBe(2)
+    unsubscribe1()
+    unsubscribe2()
+    store.set(countAtom, increment)
+    await delay(0)
+    expect(runCount).toBe(2)
+  })
+
+  it('should unsubscribe the effect when any of effect subscriptions are unsubscribed', async () => {
+    const countAtom = atom(0)
+    let runCount = 0
+
+    const effect = (get: any) => {
+      runCount++
+      get(countAtom)
+    }
+    const store = getDefaultStore()
+
+    const unsubscribe1 = observe(effect, store)
+    const unsubscribe2 = observe(effect, store)
+
+    await delay(0)
+    expect(runCount).toBe(1)
+
+    store.set(countAtom, increment)
+    await delay(0)
+    expect(runCount).toBe(2)
+    unsubscribe1()
+    store.set(countAtom, increment)
+    await delay(0)
+    expect(runCount).toBe(2)
+    unsubscribe2()
+    expect(runCount).toBe(2)
+    store.set(countAtom, increment)
+    await delay(0)
+    expect(runCount).toBe(2)
+  })
+
+  it('should work with custom store', async () => {
+    const store = createStore()
+    const countAtom = atom(0)
+    let runCount = 0
+
+    const unsubscribe = observe((get) => {
+      runCount++
+      get(countAtom)
+    }, store)
+
+    await delay(0)
+    expect(runCount).toBe(1)
+
+    store.set(countAtom, increment)
+    await delay(0)
+    expect(runCount).toBe(2)
+
+    unsubscribe()
+  })
+
+  it('should handle multiple stores independently', async () => {
+    const store1 = createStore()
+    const store2 = createStore()
+    const countAtom = atom(0)
+    const runCounts = [0, 0] as [number, number]
+
+    const storeIdAtom = atom(NaN as 0 | 1)
+    store1.set(storeIdAtom, 0)
+    store2.set(storeIdAtom, 1)
+
+    function effect(get: Getter) {
+      ++runCounts[get(storeIdAtom)]
+      get(countAtom)
+    }
+
+    const unsubscribe1 = observe(effect, store1)
+    const unsubscribe2 = observe(effect, store2)
+
+    await delay(0)
+    expect(runCounts[0]).toBe(1)
+    expect(runCounts[1]).toBe(1)
+
+    store1.set(countAtom, increment)
+    await delay(0)
+    expect(runCounts[0]).toBe(2)
+    expect(runCounts[1]).toBe(1)
+    store2.set(countAtom, increment)
+    await delay(0)
+    expect(runCounts[0]).toBe(2)
+    expect(runCounts[1]).toBe(2)
+
+    unsubscribe1()
+    store2.set(countAtom, increment)
+    await delay(0)
+    expect(runCounts[0]).toBe(2)
+    expect(runCounts[1]).toBe(3)
+    store2.set(countAtom, increment)
+    await delay(0)
+    expect(runCounts[0]).toBe(2)
+    expect(runCounts[1]).toBe(4)
+
+    unsubscribe2()
+  })
+
+  it('should handle multiple effects independently', async () => {
+    const store = createStore()
+    const countAtom = atom(0)
+    const runCounts = [0, 0] as [number, number]
+
+    function effect1(get: Getter) {
+      ++runCounts[0]
+      get(countAtom)
+    }
+    function effect2(get: Getter) {
+      ++runCounts[1]
+      get(countAtom)
+    }
+
+    const unsubscribe1 = observe(effect1, store)
+    const unsubscribe2 = observe(effect2, store)
+
+    await delay(0)
+    expect(runCounts[0]).toBe(1)
+    expect(runCounts[1]).toBe(1)
+
+    store.set(countAtom, increment)
+    await delay(0)
+    expect(runCounts[0]).toBe(2)
+    expect(runCounts[1]).toBe(2)
+
+    unsubscribe1()
+    store.set(countAtom, increment)
+    await delay(0)
+    expect(runCounts[0]).toBe(2)
+    expect(runCounts[1]).toBe(3)
+
+    unsubscribe2()
+  })
+})


### PR DESCRIPTION
## Summary
I'm excited to introduce a brand new helper function, `observe`, which simplifies and unifies the way you manage side-effects in Jotai. By leveraging `observe`, you can cleanly subscribe to state changes, automatically run (and clean up) your effects, and even share subscriptions between multiple calls—all with minimal boilerplate.

---

## API
**Type**
```ts
type Unobserve = () => void

function observe(effect: Effect, store = defaultStore()): Unobserve
```

**Example**
```ts
observe((get, set) => {
  console.log(`count is now ${get(countAtom}`)
})
```

- **Parameters:**
  - **effect** – A function that receives Jotai’s `get` and `set` methods.
  - **store (optional)** – If omitted, `observe` uses the default store.

- **Returns:**  
  A cleanup function (`unobserve`), which stops the effect and removes subscriptions when called.
---

### Key Features

1. **Streamlined Subscription**  
   Calling `observe(effect, store)` runs the effect immediately and on every relevant state change.

2. **Automatic Cleanup**  
    The returned `unobserve` function handles cleanup for you, freeing you from managing memory leaks or forgotten subscriptions.

3. **Idempotent Subscriptions**  
   Repeatedly calling `observe(effect, store)` reuses the same subscription. This means multiple parts of your app can rely on the same effect without incurring additional overhead.

4. **Independent Store Support**  
   You can attach the same or different effects to any number of stores. Each store maintains its own subscriptions, keeping your state logic isolated and modular.

5. **Multiple Effects**  
   Attach as many independent effects to a store as you need. Each effect is tracked separately, so unsubscribing one won’t affect the others.

---

#### Complete Example

```ts
import { atom, createStore } from 'jotai/vanilla'
import { observe } from './observe'

const store = createStore()
const countAtom = atom(0)

const unobserve = observe((get) => {
  console.log('Current count is', get(countAtom))
}, store)

// Now any change to `countAtom` will trigger the effect
store.set(countAtom, (v) => v + 1) // Logs: "Current count is 1"

// Cleanup when you’re done
unobserve()
```

---

#### Behind the Scenes

- **Caching Mechanism**  
  Internally, `observe` uses a `WeakMap<Store, Map<Effect, () => void>>` to avoid duplicate subscriptions.  
- **Synchronous Updates**  
  Effects run synchronously in response to state changes.  
- **Robust Operation**
  The utility handles multiple stores and concurrent effects, ensuring consistent behavior in real-world scenarios.

---

With `observe`, Jotai’s side-effect management becomes more powerful and ergonomic. I hope this utility simplifies your workflows and keeps your codebase clean and maintainable. Feedback is always welcome!