### PR TITLE
use a typeof not function cleanup guard instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 dist
 jotai
 node_modules
+.DS_Store

--- a/src/atomEffect.ts
+++ b/src/atomEffect.ts
@@ -137,7 +137,7 @@ export function atomEffect(
     }
   }
   function cleanup(ref: Ref) {
-    if (!ref.c) return
+    if (typeof ref.c !== 'function') return
     try {
       ref.fc = true
       ref.c()


### PR DESCRIPTION
## Summary
Use a stronger cleanup guard to protect against invalid return types not caught by Typescript.