### PR TITLE
safely access process global if it exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jotai-effect",
   "description": "👻🔁",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "author": "David Maskasky",
   "contributors": [

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,7 @@
+export function isDev(): boolean {
+  return Boolean(
+    typeof process !== 'undefined' &&
+      process.env?.NODE_ENV &&
+      process.env.NODE_ENV !== 'production'
+  )
+}

--- a/src/withAtomEffect.ts
+++ b/src/withAtomEffect.ts
@@ -1,6 +1,7 @@
 import type { Atom } from 'jotai/vanilla'
 import type { Effect } from './atomEffect'
 import { atomEffect } from './atomEffect'
+import { isDev } from './env'
 
 export function withAtomEffect<T extends Atom<unknown>>(
   targetAtom: T,
@@ -12,7 +13,7 @@ export function withAtomEffect<T extends Atom<unknown>>(
     getter.peek = get.peek
     return targetWithEffect.effect(getter, set)
   })
-  if (process.env.NODE_ENV !== 'production') {
+  if (isDev()) {
     Object.defineProperty(effectAtom, 'debugLabel', {
       get: () => `${targetWithEffect.debugLabel ?? 'atomWithEffect'}:effect`,
     })

--- a/tests/atomEffect.test.ts
+++ b/tests/atomEffect.test.ts
@@ -359,7 +359,7 @@ it('should return value from set.recurse', function test() {
   })
   incrementCountAtom.debugLabel = 'incrementCountAtom'
 
-  const results = [] as number[]
+  const results: number[] = []
   const effectAtom = atomEffect((get, { recurse }) => {
     const value = get(countAtom)
     if (value < 5) {

--- a/tests/observe.test.ts
+++ b/tests/observe.test.ts
@@ -91,7 +91,7 @@ describe('observe', () => {
     const store1 = createStore()
     const store2 = createStore()
     const countAtom = atom(0)
-    const runCounts = [0, 0] as [number, number]
+    const runCounts: [number, number] = [0, 0]
 
     const storeIdAtom = atom(NaN as 0 | 1)
     store1.set(storeIdAtom, 0)
@@ -129,7 +129,7 @@ describe('observe', () => {
   it('should handle multiple effects independently', async () => {
     const store = createStore()
     const countAtom = atom(0)
-    const runCounts = [0, 0] as [number, number]
+    const runCounts: [number, number] = [0, 0]
 
     function effect1(get: Getter) {
       ++runCounts[0]

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -13,7 +13,7 @@ type Store = ReturnType<typeof INTERNAL_buildStore>
 
 type Mutable<T> = { -readonly [P in keyof T]: T[P] }
 
-type BuildingBlocks = Mutable<Parameters<typeof INTERNAL_buildStore>>
+type BuildingBlocks = Mutable<ReturnType<typeof INTERNAL_getBuildingBlocks>>
 
 type DebugStore = Store & {
   ensureAtomState: NonNullable<BuildingBlocks[11]>
@@ -24,7 +24,7 @@ let storeId = 0
 export function createDebugStore(): DebugStore {
   const buildingBlocks = INTERNAL_getBuildingBlocks(
     createStore()
-  ) as unknown as BuildingBlocks
+  ) as BuildingBlocks
   const ensureAtomState = buildingBlocks[11]!
   buildingBlocks[11] = (atom) =>
     Object.assign(ensureAtomState(atom), { label: atom.debugLabel })
@@ -87,6 +87,6 @@ export function createDeferred<T = void>(
       resolve: (value: T) => res(value) ?? promise,
       reject: (message: any) => rej(message) ?? promise,
     })
-  ).then(onfulfilled, onrejected) as DeferredPromise<T>
+  ).then(onfulfilled, onrejected)
   return Object.assign(promise, resolveReject)
 }


### PR DESCRIPTION
## Fixes
https://github.com/jotaijs/jotai-effect/issues/63

## Summary
To safely access process global, we must first check if process exists in the global scope with typeof.