### PR TITLE
fix: withAtomEffect infinite loop with atoms in atom circular dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 .vscode
 dist
 jotai
+-jotai
 node_modules
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "eslint-plugin-prettier": "^5.2.3",
     "happy-dom": "^15.11.7",
     "jiti": "^2.4.2",
-    "jotai": "2.12.1",
+    "jotai": "2.12.5",
     "jotai-effect": "link:",
     "prettier": "^3.4.2",
     "react": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ devDependencies:
     specifier: ^2.4.2
     version: 2.4.2
   jotai:
-    specifier: 2.12.1
-    version: 2.12.1(@types/react@19.0.12)(react@19.0.0)
+    specifier: 2.12.5
+    version: 2.12.5(@types/react@19.0.12)(react@19.0.0)
   jotai-effect:
     specifier: 'link:'
     version: 'link:'
@@ -2296,8 +2296,8 @@ packages:
     hasBin: true
     dev: true
 
-  /jotai@2.12.1(@types/react@19.0.12)(react@19.0.0):
-    resolution: {integrity: sha512-VUW0nMPYIru5g89tdxwr9ftiVdc/nGV9jvHISN8Ucx+m1vI9dBeHemfqYzEuw5XSkmYjD/MEyApN9k6yrATsZQ==}
+  /jotai@2.12.5(@types/react@19.0.12)(react@19.0.0):
+    resolution: {integrity: sha512-G8m32HW3lSmcz/4mbqx0hgJIQ0ekndKWiYP7kWVKi0p6saLXdSoye+FZiOFyonnd7Q482LCzm8sMDl7Ar1NWDw==}
     engines: {node: '>=12.20.0'}
     peerDependencies:
       '@types/react': '>=17.0.0'

--- a/tests/atomEffect.test.ts
+++ b/tests/atomEffect.test.ts
@@ -320,7 +320,7 @@ it('should work with both set.recurse and set', function test() {
   expect(runCount).toBe(4)
 })
 
-it('should disallow synchronous set.recurse in cleanup', function test() {
+it.only('should disallow synchronous set.recurse in cleanup', function test() {
   const watchedAtom = atom(0)
   watchedAtom.debugLabel = 'watchedAtom'
 

--- a/tests/atomEffect.test.ts
+++ b/tests/atomEffect.test.ts
@@ -2,13 +2,13 @@ import type { ReactNode } from 'react'
 import { createElement } from 'react'
 import { act, render } from '@testing-library/react'
 import { Provider, useAtomValue } from 'jotai/react'
-import { describe, expect, it, vi } from 'vitest'
 import { atom } from 'jotai/vanilla'
 import {
   INTERNAL_buildStoreRev1 as INTERNAL_buildStore,
   INTERNAL_getBuildingBlocksRev1 as INTERNAL_getBuildingBlocks,
   INTERNAL_initializeStoreHooks,
 } from 'jotai/vanilla/internals'
+import { describe, expect, it, vi } from 'vitest'
 import { atomEffect } from '../src/atomEffect'
 import { DeferredPromise, createDebugStore, createDeferred } from './test-utils'
 
@@ -320,7 +320,7 @@ it('should work with both set.recurse and set', function test() {
   expect(runCount).toBe(4)
 })
 
-it.only('should disallow synchronous set.recurse in cleanup', function test() {
+it('should disallow synchronous set.recurse in cleanup', function test() {
   const watchedAtom = atom(0)
   watchedAtom.debugLabel = 'watchedAtom'
 
@@ -344,7 +344,7 @@ it.only('should disallow synchronous set.recurse in cleanup', function test() {
   try {
     store.set(anotherAtom, (v) => v + 1)
   } catch (e) {
-    error = e as Error
+    error = e instanceof AggregateError ? e.errors[0] : e
   }
   expect(error?.message).toBe('set.recurse is not allowed in cleanup')
 })
@@ -876,9 +876,14 @@ it('should throw on set when an error is thrown in effect', async function test(
   const store = createDebugStore()
   store.sub(effectAtom, () => {})
 
-  expect(() => {
+  let error: Error | undefined
+  try {
     store.set(refreshAtom, (v) => v + 1)
-  }).toThrowError('effect error')
+  } catch (e) {
+    error = e instanceof AggregateError ? e.errors[0] : e
+  }
+
+  expect(error?.message).toBe('effect error')
 })
 
 it('should throw on set when an error is thrown in cleanup', async function test() {
@@ -896,9 +901,14 @@ it('should throw on set when an error is thrown in cleanup', async function test
   const store = createDebugStore()
   store.sub(effectAtom, () => {})
 
-  expect(() => store.set(refreshAtom, (v) => v + 1)).toThrowError(
-    'effect cleanup error'
-  )
+  let error: Error | undefined
+  try {
+    store.set(refreshAtom, (v) => v + 1)
+  } catch (e) {
+    error = e instanceof AggregateError ? e.errors[0] : e
+  }
+
+  expect(error?.message).toBe('effect cleanup error')
 })
 
 it('should not suspend the component', function test() {

--- a/tests/observe.test.ts
+++ b/tests/observe.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
 import { type Getter, atom, createStore, getDefaultStore } from 'jotai/vanilla'
+import { describe, expect, it } from 'vitest'
 import { observe } from '../src/observe'
 
 describe('observe', () => {

--- a/tests/withAtomEffect.test.ts
+++ b/tests/withAtomEffect.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react'
 import { useAtomValue } from 'jotai/react'
-import { describe, expect, it, vi } from 'vitest'
 import { Getter, atom } from 'jotai/vanilla'
+import { describe, expect, it, vi } from 'vitest'
 import { atomEffect } from '../src/atomEffect'
 import { withAtomEffect } from '../src/withAtomEffect'
 import { createDebugStore } from './test-utils'


### PR DESCRIPTION
## Summary
When withAtomEffect depends on [atoms-in-atom pattern](https://jotai.org/docs/guides/atoms-in-atom), and this dependency circularly depends on withAtomEffect resulting atom, this causes an infinite loop. This is because the atoms created in the atom read function can have an onMount property that calls its setAtom param. When this happens it causes an infinite loop.

*Case example*
```ts
import { atomWithQuery } from 'jotai-tanstack-query'

const queryAtom = atomWithQuery((get) => {
  const progress = get(progressWithEffectAtom)
  return {
    queryKey: ['progress'],
    queryFn: () => Promise.resolve(progress),
  }
})
const progressAtom = atom(false)
const progressWithEffect = withAtomEffect(progressAtom, (get, set) => {
  get(queryAtom)
  ...
})
```

## Fix
The fix is to bind the atomEffect lifecycle to the lifecycle of the target atom without the target atom actually depending on the atomEffect. This is accomplished with storeHooks, a recent addition to the Jotai core api.
