### PR TITLE
Deterministic `withAtomEffect` ordering

### DIFF
--- a/src/atomEffect.ts
+++ b/src/atomEffect.ts
@@ -5,7 +5,7 @@ import type {
   INTERNAL_buildStoreRev1 as buildStore,
 } from 'jotai/vanilla/internals'
 import {
-  INTERNAL_getBuildingBlocksRev1 as INTERNAL_getBuildingBlocks,
+  INTERNAL_getBuildingBlocksRev1 as getBuildingBlocks,
   INTERNAL_hasInitialValue as hasInitialValue,
   INTERNAL_initializeStoreHooks as initializeStoreHooks,
   INTERNAL_isAtomStateInitialized as isAtomStateInitialized,
@@ -15,29 +15,13 @@ import {
 } from 'jotai/vanilla/internals'
 import { isDev } from './env'
 
-function getBuildingBlocks(store: Store) {
-  const buildingBlocks = INTERNAL_getBuildingBlocks(store)
-  return [
-    buildingBlocks[1], // mountedAtoms
-    buildingBlocks[3], // changedAtoms
-    initializeStoreHooks(buildingBlocks[6]), // storeHooks
-    buildingBlocks[11], // ensureAtomState
-    buildingBlocks[14], // readAtomState
-    buildingBlocks[16], // writeAtomState
-    buildingBlocks[17], // mountDependencies
-    buildingBlocks[15], // invalidateDependents
-    buildingBlocks[13], // recomputeInvalidatedAtoms
-    buildingBlocks[12], // flushCallbacks
-  ] as const
-}
-
 type Store = ReturnType<typeof buildStore>
 
 type AnyAtom = Atom<unknown>
 
-type GetterWithPeek = Getter & { peek: Getter }
+export type GetterWithPeek = Getter & { peek: Getter }
 
-type SetterWithRecurse = Setter & { recurse: Setter }
+export type SetterWithRecurse = Setter & { recurse: Setter }
 
 type Cleanup = () => void
 
@@ -202,18 +186,18 @@ export function atomEffect(effect: Effect): Atom<void> & { effect: Effect } {
       }
     }
 
-    const [
-      mountedAtoms,
-      changedAtoms,
-      storeHooks,
-      ensureAtomState,
-      readAtomState,
-      writeAtomState,
-      mountDependencies,
-      invalidateDependents,
-      recomputeInvalidatedAtoms,
-      flushCallbacks,
-    ] = getBuildingBlocks(store)
+    const buildingBlocks = getBuildingBlocks(store)
+    const mountedAtoms = buildingBlocks[1]
+    const changedAtoms = buildingBlocks[3]
+    const storeHooks = initializeStoreHooks(buildingBlocks[6])
+    const ensureAtomState = buildingBlocks[11]
+    const flushCallbacks = buildingBlocks[12]
+    const recomputeInvalidatedAtoms = buildingBlocks[13]
+    const readAtomState = buildingBlocks[14]
+    const invalidateDependents = buildingBlocks[15]
+    const writeAtomState = buildingBlocks[16]
+    const mountDependencies = buildingBlocks[17]
+
     const atomEffectChannel = ensureAtomEffectChannel(store)
     const atomState = ensureAtomState(effectAtom)
     // initialize atomState
@@ -264,7 +248,8 @@ type AtomEffectChannel = Set<() => void>
 const atomEffectChannelStoreMap = new WeakMap<Store, AtomEffectChannel>()
 
 function ensureAtomEffectChannel(store: Store): AtomEffectChannel {
-  const storeHooks = getBuildingBlocks(store)[2]
+  const buildingBlocks = getBuildingBlocks(store)
+  const storeHooks = initializeStoreHooks(buildingBlocks[6])
   let atomEffectChannel = atomEffectChannelStoreMap.get(store)
   if (!atomEffectChannel) {
     atomEffectChannel = new Set()

--- a/src/withAtomEffect.ts
+++ b/src/withAtomEffect.ts
@@ -23,17 +23,13 @@ export function withAtomEffect<T extends Atom<unknown>>(
     })
     effectAtom.debugPrivate = true
   }
-  const descriptors = Object.getOwnPropertyDescriptors(targetAtom)
-  descriptors.read.value = targetAtom.read.bind(targetAtom)
+  const proto = Object.getPrototypeOf(targetAtom)
+  const desc = Object.getOwnPropertyDescriptors(targetAtom)
+  desc.read.value = targetAtom.read.bind(targetAtom)
   if ('write' in targetAtom && typeof targetAtom.write === 'function') {
-    descriptors.write!.value = targetAtom.write.bind(targetAtom)
+    desc.write!.value = targetAtom.write.bind(targetAtom)
   }
-  // avoid reading `init` to preserve lazy initialization
-  const targetPrototype = Object.getPrototypeOf(targetAtom)
-  const targetWithEffect: T & { effect: Effect } = Object.create(
-    targetPrototype,
-    descriptors
-  )
+  const targetWithEffect: T & { effect: Effect } = Object.create(proto, desc)
   targetWithEffect.unstable_onInit = (store) => {
     const buildingBlocks = getBuildingBlocks(store)
     const storeHooks = initializeStoreHooks(buildingBlocks[6])

--- a/src/withAtomEffect.ts
+++ b/src/withAtomEffect.ts
@@ -1,9 +1,9 @@
-import type { Atom } from 'jotai/vanilla'
+import type { Atom, WritableAtom } from 'jotai/vanilla'
 import {
   INTERNAL_getBuildingBlocksRev1 as getBuildingBlocks,
   INTERNAL_initializeStoreHooks as initializeStoreHooks,
 } from 'jotai/vanilla/internals'
-import type { Effect } from './atomEffect'
+import type { Effect, GetterWithPeek, SetterWithRecurse } from './atomEffect'
 import { atomEffect } from './atomEffect'
 import { isDev } from './env'
 
@@ -11,36 +11,107 @@ export function withAtomEffect<T extends Atom<unknown>>(
   targetAtom: T,
   effect: Effect
 ): T & { effect: Effect } {
-  const effectAtom = atomEffect((get, set) => {
-    const getter = ((a) =>
-      a === targetWithEffect ? get(targetAtom) : get(a)) as typeof get
-    getter.peek = get.peek
-    return targetWithEffect.effect.call(targetAtom, getter, set)
-  })
-  if (isDev()) {
-    Object.defineProperty(effectAtom, 'debugLabel', {
-      get: () => `${targetWithEffect.debugLabel ?? 'atomWithEffect'}:effect`,
-    })
-    effectAtom.debugPrivate = true
-  }
   const proto = Object.getPrototypeOf(targetAtom)
   const desc = Object.getOwnPropertyDescriptors(targetAtom)
-  desc.read.value = targetAtom.read.bind(targetAtom)
-  if ('write' in targetAtom && typeof targetAtom.write === 'function') {
-    desc.write!.value = targetAtom.write.bind(targetAtom)
+  let depth = 0
+  desc.read.value = function read(get, options) {
+    try {
+      ++depth
+      // handles case when withAtomEffect is nested
+      const context = depth === 1 ? targetAtom : this
+      return targetAtom.read.call(context, get, options)
+    } finally {
+      --depth
+    }
+  }
+  if (isWritableAtom(targetAtom)) {
+    desc.write!.value = function write(this: T, get, set, ...args) {
+      try {
+        ++depth
+        const context = depth === 1 ? targetAtom : this
+        return targetAtom.write.call(context, get, set, ...args)
+      } finally {
+        --depth
+      }
+    } as (typeof targetAtom)['write']
   }
   const targetWithEffect: T & { effect: Effect } = Object.create(proto, desc)
   targetWithEffect.unstable_onInit = (store) => {
     const buildingBlocks = getBuildingBlocks(store)
+    const invalidatedAtoms = buildingBlocks[2]
     const storeHooks = initializeStoreHooks(buildingBlocks[6])
-    let unsub: () => void
+    const ensureAtomState = buildingBlocks[11]
+    const flushCallbacks = buildingBlocks[12]
+    const readAtomState = buildingBlocks[14]
+    const mountDependencies = buildingBlocks[17]
+    const mountAtom = buildingBlocks[18]
+    const unmountAtom = buildingBlocks[19]
+
+    let inProgress = false
+    let isSubscribed = false
+    const effectAtom = atomEffect((get, set) => {
+      if (inProgress) {
+        return
+      }
+      isSubscribed = false
+      const getter: GetterWithPeek = (a) => {
+        if (a === targetWithEffect) {
+          isSubscribed = true
+          return get.peek(a)
+        }
+        return get(a)
+      }
+      getter.peek = get.peek
+      const setter: SetterWithRecurse = (a, ...args) => {
+        if (a === (targetWithEffect as any)) {
+          inProgress = true
+          return set(a, ...args)
+        }
+        return set(a, ...args)
+      }
+      setter.recurse = (...args) => {
+        inProgress = false
+        return set.recurse(...args)
+      }
+      return targetWithEffect.effect.call(targetAtom, getter, setter)
+    })
+    if (isDev()) {
+      Object.defineProperty(effectAtom, 'debugLabel', {
+        get: () => `${targetWithEffect.debugLabel ?? 'atom'}:effect`,
+      })
+      effectAtom.debugPrivate = true
+    }
+    const effectAtomState = ensureAtomState(effectAtom)
+    const targetWithEffectAtomState = ensureAtomState(targetWithEffect)
+
+    storeHooks.c.add(targetWithEffect, function atomChanged() {
+      if (isSubscribed) {
+        invalidatedAtoms.set(effectAtom, effectAtomState.n)
+        effectAtomState.d.set(targetWithEffect, targetWithEffectAtomState.n - 1)
+        readAtomState(effectAtom)
+        mountDependencies(effectAtom)
+        invalidatedAtoms.delete(effectAtom)
+        effectAtomState.d.delete(targetWithEffect)
+      }
+    })
     storeHooks.m.add(targetWithEffect, function mountEffect() {
-      unsub = store.sub(effectAtom, () => {})
+      mountAtom(effectAtom)
+      flushCallbacks()
     })
     storeHooks.u.add(targetWithEffect, function unmountEffect() {
-      unsub!()
+      unmountAtom(effectAtom)
+      flushCallbacks()
+    })
+    storeHooks.f.add(function flushEffect() {
+      inProgress = false
     })
   }
   targetWithEffect.effect = effect
   return targetWithEffect
+}
+
+function isWritableAtom(
+  atom: Atom<unknown>
+): atom is WritableAtom<unknown, any[], any> {
+  return 'write' in atom && typeof atom.write === 'function'
 }


### PR DESCRIPTION
## Summary

Related Issue: https://github.com/jotaijs/jotai-effect/issues/71

This PR fixes two issues in `withAtomEffect`:

1. Effect execution order for chained `withAtomEffect` atoms was non-deterministic (`cba`/`bac` instead of `abc`) under certain mount patterns.

2. `this` binding for wrapped atoms was incorrect at the top level, causing surprising reads/writes when the base atom’s `read`/`write` depends on its receiver.

The solution provides deterministic, top-down effect execution while keeping `recomputeInvalidatedAtoms` unchanged and preserves correct `this` at the top level for both `read` and `write`.

---

## The issue

```ts
// Expect topological order: a -> b -> c
const ori = atom(0)

const a = withAtomEffect(ori, (get) => {
  get(a)              // effect "subscribes to itself" to react to ori changes
  order.push('a')
})

const b = withAtomEffect(a, (get) => {
  get(b)
  order.push('b')
})

const c = withAtomEffect(b, (get) => {
  get(c)
  order.push('c')
})

const store = createDebugStore()
store.sub(a, () => {})
store.sub(b, () => {})
store.sub(c, () => {})

order.length = 0
store.set(a, (v) => v + 1)

// Expected: "abc"
// Received (intermittent): "cba" or "bac"
expect(order.join('')).toBe('abc')
```

### Cause

* Scheduling source: The previous implementation relied on the effect atom’s own recompute/change hook to trigger runs. Because `recomputeInvalidatedAtoms` uses a DFS over dependents and Set insertion order, sibling visitation could yield `cba`/`bac` depending on mount/insert order. Order was an implementation detail, not a contract.
* Receiver context: The wrapped atom’s `read`/`write` were bound to the wrong `this` at the top level, which breaks atoms that internally rely on their receiver identity.

---

## Approach

### 1) Correct `this` binding at the top level

Wrap `read`/`write` and detect top-level entry (vs nested calls) with a small depth counter. At depth 1, bind to the original target atom; otherwise preserve `this` for nested calls.

```ts
let depth = 0

desc.read.value = function read(get, options) {
  depth++
  try {
    const ctx = depth === 1 ? targetAtom : this
    return targetAtom.read.call(ctx, get, options)
  } finally {
    depth--
  }
}

if (isWritableAtom(targetAtom)) {
  desc.write!.value = function write(this: T, get, set, ...args) {
    depth++
    try {
      const ctx = depth === 1 ? targetAtom : this
      return targetAtom.write.call(ctx, get, set, ...args)
    } finally {
      depth--
    }
  } as (typeof targetAtom)['write']
}
```

This makes wrapped atoms behave exactly like the original atom at the public boundary, while keeping nested semantics intact.

### 2) Deterministic effect runs, bound to the wrapped target

Keep the internal `effectAtom`, but:

* Mark “subscribed to self” only when the effect executes `get(enhanced)`; use `getter.peek` so the wrapper is not tracked as a real dependency.
* Re-run the effect when the wrapped target changes (store hook `c` on the target), only if the effect previously “subscribed to self”.

To guarantee the recompute path without altering the global topo walk, temporarily inject a synthetic dependency so that the effect is considered invalidated, then remove it immediately:

```ts
storeHooks.c.add(targetWithEffect, () => {
  if (isSubscribed) {
    invalidatedAtoms.set(effectAtom, effectAtomState.n)
    effectAtomState.d.set(targetWithEffect, targetWithEffectAtomState.n + 1)
    readAtomState(effectAtom)
    mountDependencies(effectAtom)
    invalidatedAtoms.delete(effectAtom)
    effectAtomState.d.delete(targetWithEffect)
  }
})
```

Add a minimal reentrancy guard (`inProgress`) to prevent recursive self-triggers inside a single flush, resetting it at `storeHooks.f` (end of flush).

### 3) Clean mount/unmount lifecycle

Mount `effectAtom` when the wrapper mounts and unmount it when the wrapper unmounts, keeping subscriptions and cleanup counts consistent and avoiding leaks.

---

## Why this yields `abc`

The scheduling source is now the wrapped target, not the effect’s own recompute timing. When `a` changes, `a`’s effect is queued first, then `b`’s, then `c`’s, producing a top-down order. `recomputeInvalidatedAtoms` remains unchanged and compatible with upstream internals.

