### PR TITLE
fix: export Effect to resolve ts(2742) in some project setups

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { atomEffect } from './atomEffect'
+export { atomEffect, type Effect } from './atomEffect'
 export { withAtomEffect } from './withAtomEffect'
 export { observe } from './observe'


### PR DESCRIPTION
We are facing issues in a project that has the typescript setting `"declaration": true` enabled. The following code fails:

```ts
export const exampleEffect = atomEffect(() => {
    // nothing here
})

export const exampleAtom = withAtomEffect(atom(0), () => {
  // nothing here
});
```

We get the following error:

```
The inferred type of 'exampleAtom' cannot be named without a reference to '../node_modules/jotai-effect/dist/atomEffect'. This is likely not portable. A type annotation is necessary.ts(2742)

const exampleAtom: PrimitiveAtom<number> & WithInitialValue<number> & {
    effect: Effect;
}
```

This PR exports the `Effect` type from `atomEffect`. See https://github.com/dhenneke/jotai-effect-export for a reproduction of the issue.
