### PR TITLE
fix: double mount of atomEffect dependents

### DIFF
--- a/src/withAtomEffect.ts
+++ b/src/withAtomEffect.ts
@@ -98,14 +98,19 @@ export function withAtomEffect<T extends Atom<unknown>>(
     storeHooks.m.add(targetWithEffect, function mountEffect() {
       const atomState = ensureAtomState(store, targetWithEffect)
       const { n } = atomState
-      mountAtom(store, effectAtom)
-      flushCallbacks(store)
-      if (n !== atomState.n) {
-        const unsub = storeHooks.f.add(() => {
-          invalidateDependents(store, targetWithEffect)
-          unsub()
-        })
-      }
+      // Defer effect mount to the next flush `f` so nested mount waves do not replace mounted maps
+      // after inner passes have populated mounted.t, which can strand invalidation edges (#3292).
+      const unsubFlush = storeHooks.f.add(() => {
+        unsubFlush()
+        mountAtom(store, effectAtom)
+        if (n !== atomState.n) {
+          const unsubPost = storeHooks.f.add(() => {
+            unsubPost()
+            invalidateDependents(store, targetWithEffect)
+          })
+        }
+        flushCallbacks(store)
+      })
     })
     storeHooks.u.add(targetWithEffect, function unmountEffect() {
       unmountAtom(store, effectAtom)

--- a/tests/withAtomEffect.test.ts
+++ b/tests/withAtomEffect.test.ts
@@ -423,4 +423,50 @@ describe('withAtomEffect', () => {
 
     expect(store.get(atomC)).toBe(true)
   })
+
+  it('defers effect mount to avoid double-mount desync between sibling readers', function test() {
+    // https://github.com/pmndrs/jotai/discussions/3292
+    const store = createDebugStore()
+    const countAtom = atom(0)
+    const tickerValueAtom = atom(0)
+    const tickerAtom = withAtomEffect(tickerValueAtom, (get, set) => {
+      const count = get(countAtom)
+      set(tickerValueAtom, count)
+    })
+    const derivedAtom = atom((get) => get(tickerAtom) * 1000)
+    const t1Atom = atom((get: Getter) => get(derivedAtom))
+    const t2Atom = atom((get: Getter) => get(derivedAtom))
+
+    let t1: number | undefined
+    let t2: number | undefined
+    const t0Atom = atom((get) => {
+      const count = get(countAtom)
+      if (count === 1) {
+        return
+      }
+      t1 = get(t1Atom)
+      t2 = get(t2Atom)
+    })
+
+    const unsub = store.sub(t0Atom, () => {})
+
+    expect(t1).toBe(0)
+    expect(t2).toBe(0)
+
+    store.set(countAtom, 1)
+    expect(t1).toBe(0)
+    expect(t2).toBe(0)
+
+    store.set(countAtom, 2)
+    expect(t1).toBe(t2)
+
+    store.set(countAtom, 3)
+    expect(t1).toBe(t2)
+
+    store.set(countAtom, 4)
+    expect(t1).toBe(t2)
+    expect(t1).toBe(4000)
+
+    unsub()
+  })
 })


### PR DESCRIPTION
## Summary

Fixes sibling readers of the same derived atom diverging when it sits behind `withAtomEffect` ([discussion #3292](https://github.com/pmndrs/jotai/discussions/3292)). Changes are limited to `jotai-effect` (`withAtomEffect` mount/flush scheduling).

## Problem

Nested mount waves: mounting the inner `atomEffect` while an outer mount wave is still running lets the inner pass record transient inverse-dependency edges on `mounted.t`. The outer pass can then replace `mounted` (new `{ l, d, t }`) and drop those edges. On later updates, the read path may only revisit the first changed atom before the dependency loop stops; later atoms in the batch are skipped, so two siblings that both read the same derived can see different cached values.

## Solution

1. Defer `mountAtom(effectAtom)` to the next `storeHooks.f` pass (one-shot `storeHooks.f.add`), so the inner effect does not run nested inside the wrapper’s mount wave.

2. After that deferred run, `flushCallbacks(store)` once (`buildingBlocks[12]`) so the nested flush loop can run multiple top-of-iteration `f` passes and drain the atom-effect channel and any pending mount/unmount/changed work in the same `store.set` / `store.sub` transaction.

3. If the wrapper’s `atomState.n` changed between entering `mountEffect` and finishing the effect mount flush, register `invalidateDependents(store, targetWithEffect)` on the next `f`, before that single `flushCallbacks`, so dependent invalidation is scheduled and then flushed in the same nested `flushCallbacks` call.
