### PR TITLE
V3 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "eslint-plugin-prettier": "^5.2.3",
     "happy-dom": "^15.11.7",
     "jiti": "^2.4.2",
-    "jotai": "^2.20.0",
+    "jotai": "3.0.0-alpha.0",
     "jotai-effect": "link:",
     "prettier": "^3.4.2",
     "react": "19.2.1",
@@ -98,7 +98,7 @@
     "vitest": "^3.0.3"
   },
   "peerDependencies": {
-    "jotai": ">=2.20.0"
+    "jotai": ">=2.20.0 || >=3.0.0-alpha.0"
   },
   "engines": {
     "node": ">=12.20.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
       jotai:
-        specifier: ^2.20.0
-        version: 2.20.0(@types/react@19.2.7)(react@19.2.1)
+        specifier: 3.0.0-alpha.0
+        version: 3.0.0-alpha.0(@types/react@19.2.7)(react@19.2.1)
       jotai-effect:
         specifier: 'link:'
         version: 'link:'
@@ -1274,19 +1274,13 @@ packages:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
 
-  jotai@2.20.0:
-    resolution: {integrity: sha512-b5GAqgmXmXzB4WPaTH26ppk9Sl7AA9WSQX7yfdM+gJ1rFROiWcVbi97gFuN/yVCojOcbcvop2sfLL+fjxW0JVg==}
-    engines: {node: '>=12.20.0'}
+  jotai@3.0.0-alpha.0:
+    resolution: {integrity: sha512-g5QiW70SgjIKMuw4js6j2dqHuXIib22qUL68ndCzym2i3RIcee78ftKflGtDJLkH+u1Fykjg4sfCx46+e3nkFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      '@babel/core': '>=7.0.0'
-      '@babel/template': '>=7.0.0'
-      '@types/react': '>=17.0.0'
-      react: '>=17.0.0'
+      '@types/react': '>=18.0.0'
+      react: '>=18.0.0'
     peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@babel/template':
-        optional: true
       '@types/react':
         optional: true
       react:
@@ -3096,7 +3090,7 @@ snapshots:
 
   jiti@2.4.2: {}
 
-  jotai@2.20.0(@types/react@19.2.7)(react@19.2.1):
+  jotai@3.0.0-alpha.0(@types/react@19.2.7)(react@19.2.1):
     optionalDependencies:
       '@types/react': 19.2.7
       react: 19.2.1

--- a/src/atomEffect.ts
+++ b/src/atomEffect.ts
@@ -1,21 +1,30 @@
 import type { Atom, Getter, Setter, WritableAtom } from 'jotai/vanilla'
 import { atom } from 'jotai/vanilla'
+import { isDev } from './env'
 import type {
   INTERNAL_AtomState as AtomState,
   INTERNAL_MountedMap as MountedMap,
+  INTERNAL_Store as Store,
   INTERNAL_StoreHooks as StoreHooks,
-  INTERNAL_buildStoreRev3 as buildStore,
-} from 'jotai/vanilla/internals'
+} from './jotai-compat'
 import {
-  INTERNAL_getBuildingBlocksRev3 as getBuildingBlocks,
+  INTERNAL_KEY_changedAtoms,
+  INTERNAL_KEY_ensureAtomState,
+  INTERNAL_KEY_flushCallbacks,
+  INTERNAL_KEY_invalidateDependents,
+  INTERNAL_KEY_mountDependencies,
+  INTERNAL_KEY_mountedMap,
+  INTERNAL_KEY_readAtomState,
+  INTERNAL_KEY_recomputeInvalidatedAtoms,
+  INTERNAL_KEY_setAtomStateValueOrPromise,
+  INTERNAL_KEY_storeHooks,
+  INTERNAL_KEY_writeAtomState,
+  INTERNAL_getBuildingBlocks as getBuildingBlocks,
   INTERNAL_hasInitialValue as hasInitialValue,
-  INTERNAL_initializeStoreHooksRev3 as initializeStoreHooks,
+  INTERNAL_initializeStoreHooks as initializeStoreHooks,
   INTERNAL_isAtomStateInitialized as isAtomStateInitialized,
   INTERNAL_returnAtomValue as returnAtomValue,
-} from 'jotai/vanilla/internals'
-import { isDev } from './env'
-
-type Store = ReturnType<typeof buildStore>
+} from './jotai-compat'
 
 type AnyAtom = Atom<unknown>
 
@@ -51,17 +60,22 @@ export function atomEffect(effect: Effect): Atom<void> & { effect: Effect } {
 
   effectAtom.INTERNAL_onInit = (store) => {
     const buildingBlocks = getBuildingBlocks(store)
-    const mountedMap = buildingBlocks[1]
-    const changedAtoms = buildingBlocks[3]
-    const storeHooks = initializeStoreHooks(buildingBlocks[6])
-    const ensureAtomState = buildingBlocks[11]
-    const flushCallbacks = buildingBlocks[12]
-    const recomputeInvalidatedAtoms = buildingBlocks[13]
-    const readAtomState = buildingBlocks[14]
-    const invalidateDependents = buildingBlocks[15]
-    const writeAtomState = buildingBlocks[16]
-    const mountDependencies = buildingBlocks[17]
-    const setAtomStateValueOrPromise = buildingBlocks[20]
+    const mountedMap = buildingBlocks[INTERNAL_KEY_mountedMap]
+    const changedAtoms = buildingBlocks[INTERNAL_KEY_changedAtoms]
+    const storeHooks = initializeStoreHooks(
+      buildingBlocks[INTERNAL_KEY_storeHooks]
+    )
+    const ensureAtomState = buildingBlocks[INTERNAL_KEY_ensureAtomState]
+    const flushCallbacks = buildingBlocks[INTERNAL_KEY_flushCallbacks]
+    const recomputeInvalidatedAtoms =
+      buildingBlocks[INTERNAL_KEY_recomputeInvalidatedAtoms]
+    const readAtomState = buildingBlocks[INTERNAL_KEY_readAtomState]
+    const invalidateDependents =
+      buildingBlocks[INTERNAL_KEY_invalidateDependents]
+    const writeAtomState = buildingBlocks[INTERNAL_KEY_writeAtomState]
+    const mountDependencies = buildingBlocks[INTERNAL_KEY_mountDependencies]
+    const setAtomStateValueOrPromise =
+      buildingBlocks[INTERNAL_KEY_setAtomStateValueOrPromise]
 
     const deps = new Set<AnyAtom>()
     let inProgress = 0

--- a/src/jotai-compat.ts
+++ b/src/jotai-compat.ts
@@ -1,0 +1,171 @@
+import * as jt from 'jotai/vanilla/internals'
+
+export type * from 'jotai/vanilla/internals'
+export {
+  INTERNAL_addPendingPromiseToDependency,
+  INTERNAL_getMountedOrPendingDependents,
+  INTERNAL_hasInitialValue,
+  INTERNAL_isActuallyWritableAtom,
+  INTERNAL_isAtomStateInitialized,
+  INTERNAL_isPromiseLike,
+  INTERNAL_returnAtomValue,
+} from 'jotai/vanilla/internals'
+
+const REV_PREFIX = 'INTERNAL_getBuildingBlocksRev'
+
+const revision = Number(
+  Object.keys(jt)
+    .find((key) => key.startsWith(REV_PREFIX))
+    ?.slice(REV_PREFIX.length)
+)
+
+if (Number.isNaN(revision)) {
+  throw new Error('jotai-compat: unsupported jotai internals revision')
+}
+
+const api = jt as Record<string, unknown>
+
+type Store = jt.INTERNAL_Store
+type BuildingBlocks = jt.INTERNAL_BuildingBlocks
+type StoreHooks = jt.INTERNAL_StoreHooks
+
+type GetBuildingBlocks = (store: Store) => BuildingBlocks
+type InitHooks = (hooks: StoreHooks) => Required<StoreHooks>
+type BuildStoreRawV2 = (...buildingBlocks: unknown[]) => Store
+type BuildStoreRawV3 = (buildingBlocks?: Record<string, unknown>) => Store
+type ThrowSync = (error: unknown) => boolean
+
+const getBBKey = `INTERNAL_getBuildingBlocksRev${revision}`
+const initHooksKey = `INTERNAL_initializeStoreHooksRev${revision}`
+const buildStoreKey = `INTERNAL_buildStoreRev${revision}`
+const throwSyncKey = 'INTERNAL_shouldThrowSynchronously'
+
+export const INTERNAL_initializeStoreHooks = api[initHooksKey] as InitHooks
+
+const buildStoreRaw = api[buildStoreKey] as BuildStoreRawV2 | BuildStoreRawV3
+
+export function INTERNAL_buildStore(
+  buildingBlocks?: unknown[] | Record<string, unknown>
+): Store {
+  if (revision < 4) {
+    const buildingBlocksArray = buildingBlocks
+      ? Object.values(buildingBlocks)
+      : []
+    return (buildStoreRaw as BuildStoreRawV2)(...buildingBlocksArray)
+  }
+  const buildingBlocksObject = Array.isArray(buildingBlocks)
+    ? Object.fromEntries(slots.map(([_, c], i) => [c, buildingBlocks[i]]))
+    : buildingBlocks
+  return (buildStoreRaw as BuildStoreRawV3)(buildingBlocksObject)
+}
+
+export const INTERNAL_shouldThrowSynchronously = api[throwSyncKey] as ThrowSync
+
+const slots = [
+  ['atomStateMap', 'a'],
+  ['mountedMap', 'm'],
+  ['invalidatedAtoms', 'i'],
+  ['changedAtoms', 'c'],
+  ['mountCallbacks', 'q'],
+  ['unmountCallbacks', 'Q'],
+  ['storeHooks', 'h'],
+  ['atomRead', 'R'],
+  ['atomWrite', 'W'],
+  ['atomOnInit', 'I'],
+  ['atomOnMount', 'M'],
+  ['ensureAtomState', 'e'],
+  ['flushCallbacks', 'f'],
+  ['recomputeInvalidatedAtoms', 'C'],
+  ['readAtomState', 'r'],
+  ['invalidateDependents', 'd'],
+  ['writeAtomState', 'w'],
+  ['mountDependencies', 'D'],
+  ['mountAtom', 't'],
+  ['unmountAtom', 'T'],
+  ['setAtomStateValueOrPromise', 'v'],
+  ['storeGet', 'g'],
+  ['storeSet', 's'],
+  ['storeSub', 'b'],
+  ['enhanceBuildingBlocks', 'B'],
+  ['abortHandlersMap', 'p'],
+  ['registerAbortHandler', 'H'],
+  ['abortPromise', 'A'],
+  ['storeEpochHolder', 'E'],
+] as const
+
+if (revision >= 4) {
+  for (const [name, char] of slots) {
+    if (api[`INTERNAL_KEY_${name}`] !== char) {
+      throw new Error(`jotai-compat: KEY drift for ${name}`)
+    }
+  }
+}
+
+type SlotKeys<S extends readonly (readonly [string, string])[]> = {
+  -readonly [I in keyof S as I extends `${number}`
+    ? `INTERNAL_KEY_${S[I][0]}`
+    : never]: I extends `${infer N extends number}`
+    ? S[I][1] extends keyof BuildingBlocks
+      ? S[I][1]
+      : N
+    : never
+}
+
+const K = {} as SlotKeys<typeof slots>
+slots.forEach(([name, c], i) => {
+  K[`INTERNAL_KEY_${name}`] = (revision >= 4 ? c : i) as never
+})
+
+export const {
+  INTERNAL_KEY_atomStateMap,
+  INTERNAL_KEY_mountedMap,
+  INTERNAL_KEY_invalidatedAtoms,
+  INTERNAL_KEY_changedAtoms,
+  INTERNAL_KEY_mountCallbacks,
+  INTERNAL_KEY_unmountCallbacks,
+  INTERNAL_KEY_storeHooks,
+  INTERNAL_KEY_atomRead,
+  INTERNAL_KEY_atomWrite,
+  INTERNAL_KEY_atomOnInit,
+  INTERNAL_KEY_atomOnMount,
+  INTERNAL_KEY_ensureAtomState,
+  INTERNAL_KEY_flushCallbacks,
+  INTERNAL_KEY_recomputeInvalidatedAtoms,
+  INTERNAL_KEY_readAtomState,
+  INTERNAL_KEY_invalidateDependents,
+  INTERNAL_KEY_writeAtomState,
+  INTERNAL_KEY_mountDependencies,
+  INTERNAL_KEY_mountAtom,
+  INTERNAL_KEY_unmountAtom,
+  INTERNAL_KEY_setAtomStateValueOrPromise,
+  INTERNAL_KEY_storeGet,
+  INTERNAL_KEY_storeSet,
+  INTERNAL_KEY_storeSub,
+  INTERNAL_KEY_enhanceBuildingBlocks,
+  INTERNAL_KEY_abortHandlersMap,
+  INTERNAL_KEY_registerAbortHandler,
+  INTERNAL_KEY_abortPromise,
+  INTERNAL_KEY_storeEpochHolder,
+} = K
+
+const rawGetBuildingBlocks = api[getBBKey] as GetBuildingBlocks
+
+const processed = new WeakMap<Record<string, unknown>, BuildingBlocks>()
+
+export const INTERNAL_getBuildingBlocks = (store: Store): BuildingBlocks => {
+  const raw = rawGetBuildingBlocks(store) as unknown as Record<string, unknown>
+  let buildingBlocks = processed.get(raw)
+  if (!buildingBlocks) {
+    buildingBlocks = (Array.isArray(raw) ? [] : {}) as BuildingBlocks
+    slots.forEach(([_, c], i) => {
+      const value = Object.prototype.hasOwnProperty.call(raw, c)
+        ? raw[c]
+        : raw[i]
+      const attributes = { value, enumerable: true }
+      Object.defineProperty(buildingBlocks, i, attributes)
+      Object.defineProperty(buildingBlocks, c, attributes)
+    })
+    processed.set(raw, buildingBlocks)
+  }
+  return buildingBlocks as BuildingBlocks
+}

--- a/src/withAtomEffect.ts
+++ b/src/withAtomEffect.ts
@@ -1,11 +1,20 @@
 import type { Atom, WritableAtom } from 'jotai/vanilla'
-import {
-  INTERNAL_getBuildingBlocksRev3 as getBuildingBlocks,
-  INTERNAL_initializeStoreHooksRev3 as initializeStoreHooks,
-} from 'jotai/vanilla/internals'
 import type { Effect, GetterWithPeek, SetterWithRecurse } from './atomEffect'
 import { atomEffect } from './atomEffect'
 import { isDev } from './env'
+import {
+  INTERNAL_KEY_ensureAtomState,
+  INTERNAL_KEY_flushCallbacks,
+  INTERNAL_KEY_invalidateDependents,
+  INTERNAL_KEY_invalidatedAtoms,
+  INTERNAL_KEY_mountAtom,
+  INTERNAL_KEY_mountDependencies,
+  INTERNAL_KEY_readAtomState,
+  INTERNAL_KEY_storeHooks,
+  INTERNAL_KEY_unmountAtom,
+  INTERNAL_getBuildingBlocks as getBuildingBlocks,
+  INTERNAL_initializeStoreHooks as initializeStoreHooks,
+} from './jotai-compat'
 
 export function withAtomEffect<T extends Atom<unknown>>(
   targetAtom: T,
@@ -38,15 +47,18 @@ export function withAtomEffect<T extends Atom<unknown>>(
   const targetWithEffect: T & { effect: Effect } = Object.create(proto, desc)
   targetWithEffect.INTERNAL_onInit = (store) => {
     const buildingBlocks = getBuildingBlocks(store)
-    const invalidatedAtoms = buildingBlocks[2]
-    const storeHooks = initializeStoreHooks(buildingBlocks[6])
-    const ensureAtomState = buildingBlocks[11]
-    const flushCallbacks = buildingBlocks[12]
-    const readAtomState = buildingBlocks[14]
-    const invalidateDependents = buildingBlocks[15]
-    const mountDependencies = buildingBlocks[17]
-    const mountAtom = buildingBlocks[18]
-    const unmountAtom = buildingBlocks[19]
+    const invalidatedAtoms = buildingBlocks[INTERNAL_KEY_invalidatedAtoms]
+    const storeHooks = initializeStoreHooks(
+      buildingBlocks[INTERNAL_KEY_storeHooks]
+    )
+    const ensureAtomState = buildingBlocks[INTERNAL_KEY_ensureAtomState]
+    const flushCallbacks = buildingBlocks[INTERNAL_KEY_flushCallbacks]
+    const readAtomState = buildingBlocks[INTERNAL_KEY_readAtomState]
+    const invalidateDependents =
+      buildingBlocks[INTERNAL_KEY_invalidateDependents]
+    const mountDependencies = buildingBlocks[INTERNAL_KEY_mountDependencies]
+    const mountAtom = buildingBlocks[INTERNAL_KEY_mountAtom]
+    const unmountAtom = buildingBlocks[INTERNAL_KEY_unmountAtom]
 
     let inProgress = false
     let isSubscribed = false

--- a/tests/atomEffect.test.ts
+++ b/tests/atomEffect.test.ts
@@ -1,14 +1,24 @@
 import type { ReactNode } from 'react'
 import { createElement } from 'react'
 import { act, render } from '@testing-library/react'
-import { Provider, useAtomValue } from 'jotai/react'
-import { atom, createStore } from 'jotai/vanilla'
-import {
-  INTERNAL_getBuildingBlocksRev3 as getBuildingBlocks,
-  INTERNAL_initializeStoreHooksRev3 as initializeStoreHooks,
-} from 'jotai/vanilla/internals'
+import { Provider, atom, createStore, useAtomValue } from 'jotai'
 import { describe, expect, it, vi } from 'vitest'
 import { atomEffect } from '../src/atomEffect'
+import type { INTERNAL_BuildingBlocks as BuildingBlocks } from '../src/jotai-compat'
+import {
+  INTERNAL_KEY_changedAtoms,
+  INTERNAL_KEY_ensureAtomState,
+  INTERNAL_KEY_flushCallbacks,
+  INTERNAL_KEY_invalidateDependents,
+  INTERNAL_KEY_mountDependencies,
+  INTERNAL_KEY_mountedMap,
+  INTERNAL_KEY_readAtomState,
+  INTERNAL_KEY_recomputeInvalidatedAtoms,
+  INTERNAL_KEY_storeHooks,
+  INTERNAL_KEY_writeAtomState,
+  INTERNAL_getBuildingBlocks as getBuildingBlocks,
+  INTERNAL_initializeStoreHooks as initializeStoreHooks,
+} from '../src/jotai-compat'
 import type { DeferredPromise } from './test-utils'
 import { createDebugStore, createDeferred } from './test-utils'
 
@@ -991,10 +1001,12 @@ it('should not add dependencies added asynchronously', async function test() {
 
 it('gets the right internals from the store', function test() {
   const buildingBlocks = getBuildingBlocks(createStore())
-  initializeStoreHooks(buildingBlocks[6])
-  expect(buildingBlocks[1]).toBeInstanceOf(WeakMap) // mountedAtoms
-  expect(buildingBlocks[3]).toBeInstanceOf(Set) // changedAtoms
-  expect(buildingBlocks[6]).toSatisfy(
+  initializeStoreHooks(buildingBlocks[INTERNAL_KEY_storeHooks])
+  const getBb = (key: keyof BuildingBlocks) =>
+    buildingBlocks[key] as (...args: unknown[]) => unknown
+  expect(buildingBlocks[INTERNAL_KEY_mountedMap]).toBeInstanceOf(WeakMap) // mountedAtoms
+  expect(buildingBlocks[INTERNAL_KEY_changedAtoms]).toBeInstanceOf(Set) // changedAtoms
+  expect(buildingBlocks[INTERNAL_KEY_storeHooks]).toSatisfy(
     (storeHooks: any) =>
       typeof storeHooks === 'object' &&
       storeHooks !== null &&
@@ -1007,29 +1019,45 @@ it('gets the right internals from the store', function test() {
       'f' in storeHooks &&
       typeof storeHooks.f === 'function'
   ) // storeHooks
-  expect(buildingBlocks[11].name.endsWith('ensureAtomState')).toBe(true)
-  expect(buildingBlocks[11]).toBeInstanceOf(Function)
-  expect(buildingBlocks[11]).toHaveLength(3)
-  expect(buildingBlocks[12].name.endsWith('flushCallbacks')).toBe(true)
-  expect(buildingBlocks[12]).toBeInstanceOf(Function)
-  expect(buildingBlocks[12]).toHaveLength(2)
-  expect(buildingBlocks[13].name.endsWith('recomputeInvalidatedAtoms')).toBe(
+  expect(
+    getBb(INTERNAL_KEY_ensureAtomState).name.endsWith('ensureAtomState')
+  ).toBe(true)
+  expect(getBb(INTERNAL_KEY_ensureAtomState)).toBeInstanceOf(Function)
+  expect(getBb(INTERNAL_KEY_ensureAtomState)).toHaveLength(3)
+  expect(
+    getBb(INTERNAL_KEY_flushCallbacks).name.endsWith('flushCallbacks')
+  ).toBe(true)
+  expect(getBb(INTERNAL_KEY_flushCallbacks)).toBeInstanceOf(Function)
+  expect(getBb(INTERNAL_KEY_flushCallbacks)).toHaveLength(2)
+  expect(
+    getBb(INTERNAL_KEY_recomputeInvalidatedAtoms).name.endsWith(
+      'recomputeInvalidatedAtoms'
+    )
+  ).toBe(true)
+  expect(getBb(INTERNAL_KEY_recomputeInvalidatedAtoms)).toBeInstanceOf(Function)
+  expect(getBb(INTERNAL_KEY_recomputeInvalidatedAtoms)).toHaveLength(2)
+  expect(getBb(INTERNAL_KEY_readAtomState).name.endsWith('readAtomState')).toBe(
     true
   )
-  expect(buildingBlocks[13]).toBeInstanceOf(Function)
-  expect(buildingBlocks[13]).toHaveLength(2)
-  expect(buildingBlocks[14].name.endsWith('readAtomState')).toBe(true)
-  expect(buildingBlocks[14]).toBeInstanceOf(Function)
-  expect(buildingBlocks[14]).toHaveLength(3)
-  expect(buildingBlocks[15].name.endsWith('invalidateDependents')).toBe(true)
-  expect(buildingBlocks[15]).toBeInstanceOf(Function)
-  expect(buildingBlocks[15]).toHaveLength(3)
-  expect(buildingBlocks[16].name.endsWith('writeAtomState')).toBe(true)
-  expect(buildingBlocks[16]).toBeInstanceOf(Function)
-  expect(buildingBlocks[16]).toHaveLength(4)
-  expect(buildingBlocks[17].name.endsWith('mountDependencies')).toBe(true)
-  expect(buildingBlocks[17]).toBeInstanceOf(Function)
-  expect(buildingBlocks[17]).toHaveLength(3)
+  expect(getBb(INTERNAL_KEY_readAtomState)).toBeInstanceOf(Function)
+  expect(getBb(INTERNAL_KEY_readAtomState)).toHaveLength(3)
+  expect(
+    getBb(INTERNAL_KEY_invalidateDependents).name.endsWith(
+      'invalidateDependents'
+    )
+  ).toBe(true)
+  expect(getBb(INTERNAL_KEY_invalidateDependents)).toBeInstanceOf(Function)
+  expect(getBb(INTERNAL_KEY_invalidateDependents)).toHaveLength(3)
+  expect(
+    getBb(INTERNAL_KEY_writeAtomState).name.endsWith('writeAtomState')
+  ).toBe(true)
+  expect(getBb(INTERNAL_KEY_writeAtomState)).toBeInstanceOf(Function)
+  expect(getBb(INTERNAL_KEY_writeAtomState)).toHaveLength(4)
+  expect(
+    getBb(INTERNAL_KEY_mountDependencies).name.endsWith('mountDependencies')
+  ).toBe(true)
+  expect(getBb(INTERNAL_KEY_mountDependencies)).toBeInstanceOf(Function)
+  expect(getBb(INTERNAL_KEY_mountDependencies)).toHaveLength(3)
 })
 
 it('should not run the effect when the effectAtom is unmounted', function test() {
@@ -1070,7 +1098,9 @@ it('should cause change hooks to fire once when effect updates the watched atom'
 
   const store = createDebugStore()
   const buildingBlocks = getBuildingBlocks(store)
-  const storeHooks = initializeStoreHooks(buildingBlocks[6])
+  const storeHooks = initializeStoreHooks(
+    buildingBlocks[INTERNAL_KEY_storeHooks]
+  )
   const countChanged = vi.fn()
   storeHooks.c.add(countAtom, countChanged)
   const effectChanged = vi.fn()

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -1,31 +1,41 @@
 import type {
+  INTERNAL_AtomStateMap as AtomStateMap,
+  INTERNAL_Callbacks as Callbacks,
+  INTERNAL_ChangedAtoms as ChangedAtoms,
   INTERNAL_BuildingBlocks,
+  INTERNAL_InvalidatedAtoms as InvalidatedAtoms,
+  INTERNAL_MountedMap as MountedMap,
   INTERNAL_Store as Store,
-} from 'jotai/vanilla/internals'
+  INTERNAL_StoreHooks as StoreHooks,
+} from '../src/jotai-compat'
 import {
-  INTERNAL_buildStoreRev3 as buildStore,
-  INTERNAL_getBuildingBlocksRev3 as getBuildingBlocks,
-  INTERNAL_initializeStoreHooksRev3 as initializeStoreHooks,
-} from 'jotai/vanilla/internals'
+  INTERNAL_KEY_atomStateMap,
+  INTERNAL_KEY_changedAtoms,
+  INTERNAL_KEY_ensureAtomState,
+  INTERNAL_KEY_invalidatedAtoms,
+  INTERNAL_KEY_mountCallbacks,
+  INTERNAL_KEY_mountedMap,
+  INTERNAL_KEY_storeHooks,
+  INTERNAL_KEY_unmountCallbacks,
+  INTERNAL_buildStore as buildStore,
+  INTERNAL_getBuildingBlocks as getBuildingBlocks,
+  INTERNAL_initializeStoreHooks as initializeStoreHooks,
+} from '../src/jotai-compat'
 
 //
 // Debug Store
 //
 
-type Mutable<T> = { -readonly [P in keyof T]: T[P] }
-
-type BuildingBlocks = Mutable<INTERNAL_BuildingBlocks>
-
 type DebugStore = Store & {
   name: string
   state: {
-    atomStateMap: BuildingBlocks[0]
-    mountedMap: BuildingBlocks[1]
-    invalidatedAtoms: BuildingBlocks[2]
-    changedAtoms: BuildingBlocks[3]
-    mountCallbacks: BuildingBlocks[4]
-    unmountCallbacks: BuildingBlocks[5]
-    storeHooks: BuildingBlocks[6]
+    atomStateMap: AtomStateMap
+    mountedMap: MountedMap
+    invalidatedAtoms: InvalidatedAtoms
+    changedAtoms: ChangedAtoms
+    mountCallbacks: Callbacks
+    unmountCallbacks: Callbacks
+    storeHooks: Required<StoreHooks>
   }
 }
 
@@ -33,20 +43,25 @@ let storeId = 0
 export function createDebugStore(
   name: string = `debug${storeId++}`
 ): DebugStore {
-  const buildingBlocks: BuildingBlocks = [...getBuildingBlocks(buildStore())]
-  const ensureAtomState = buildingBlocks[11]
-  buildingBlocks[11] = (bb, store, atom) =>
+  const raw = getBuildingBlocks(buildStore())
+  const buildingBlocks = (
+    Array.isArray(raw)
+      ? [...(raw as unknown[])]
+      : { ...(raw as Record<string, unknown>) }
+  ) as INTERNAL_BuildingBlocks
+  const ensureAtomState = buildingBlocks[INTERNAL_KEY_ensureAtomState]
+  buildingBlocks[INTERNAL_KEY_ensureAtomState] = (bb, store, atom) =>
     Object.assign(ensureAtomState(bb, store, atom), { label: atom.debugLabel })
-  const debugStore = buildStore(...buildingBlocks) as DebugStore
+  const debugStore = buildStore(buildingBlocks) as DebugStore
   debugStore.name = name
   debugStore.state = {
-    atomStateMap: buildingBlocks[0],
-    mountedMap: buildingBlocks[1],
-    invalidatedAtoms: buildingBlocks[2],
-    changedAtoms: buildingBlocks[3],
-    mountCallbacks: buildingBlocks[4],
-    unmountCallbacks: buildingBlocks[5],
-    storeHooks: initializeStoreHooks(buildingBlocks[6]),
+    atomStateMap: buildingBlocks[INTERNAL_KEY_atomStateMap],
+    mountedMap: buildingBlocks[INTERNAL_KEY_mountedMap],
+    invalidatedAtoms: buildingBlocks[INTERNAL_KEY_invalidatedAtoms],
+    changedAtoms: buildingBlocks[INTERNAL_KEY_changedAtoms],
+    mountCallbacks: buildingBlocks[INTERNAL_KEY_mountCallbacks],
+    unmountCallbacks: buildingBlocks[INTERNAL_KEY_unmountCallbacks],
+    storeHooks: initializeStoreHooks(buildingBlocks[INTERNAL_KEY_storeHooks]),
   }
   return debugStore
 }


### PR DESCRIPTION
## Summary

Adds `jotai-compat.ts` which adds support for both Jotai v2 and v3.

## Test
Confirmed jotai-effect tests pass with versions `v2.20.0` and `v3.0.0-alpha.0`.